### PR TITLE
fix(core): populate result.toolCalls after a native tool round trip

### DIFF
--- a/docs/api/classes/NeuroLink.md
+++ b/docs/api/classes/NeuroLink.md
@@ -469,7 +469,7 @@ Gracefully shutdown NeuroLink and all MCP connections
 
 > **generateText**(`options`): `Promise`\<[`TextGenerationResult`](../type-aliases/TextGenerationResult.md)\>
 
-Defined in: [neurolink.ts:6506](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L6506)
+Defined in: [neurolink.ts:6507](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L6507)
 
 BACKWARD COMPATIBILITY: Legacy generateText method
 Internally calls generate() and converts result format
@@ -490,7 +490,7 @@ Internally calls generate() and converts result format
 
 > **streamText**(`prompt`, `options?`): `Promise`\<`AsyncIterable`\<`string`, `any`, `any`\>\>
 
-Defined in: [neurolink.ts:8998](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L8998)
+Defined in: [neurolink.ts:9004](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L9004)
 
 BACKWARD COMPATIBILITY: Legacy streamText method
 Internally calls stream() and converts result format
@@ -515,7 +515,7 @@ Internally calls stream() and converts result format
 
 > **stream**(`options`): `Promise`\<[`StreamResult`](../type-aliases/StreamResult.md)\>
 
-Defined in: [neurolink.ts:9081](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L9081)
+Defined in: [neurolink.ts:9087](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L9087)
 
 Stream AI-generated content in real-time using the best available provider.
 This method provides real-time streaming of AI responses with full MCP tool integration.
@@ -588,7 +588,7 @@ When conversation memory operations fail (if enabled)
 
 > **setToolRoutingServers**(`servers`): `void`
 
-Defined in: [neurolink.ts:9973](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L9973)
+Defined in: [neurolink.ts:9979](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L9979)
 
 Supplies (or replaces) the pre-call tool routing server catalog.
 
@@ -613,7 +613,7 @@ alone does not activate it.
 
 > **getKnowledgeStatus**(): [`KnowledgeEngineStatus`](../type-aliases/KnowledgeEngineStatus.md) \| `null`
 
-Defined in: [neurolink.ts:9991](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L9991)
+Defined in: [neurolink.ts:9997](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L9997)
 
 Knowledge-grounding engine health (null when it was not configured).
 
@@ -627,7 +627,7 @@ Knowledge-grounding engine health (null when it was not configured).
 
 > **getEventEmitter**(): `TypedEventEmitter`\<[`NeuroLinkEvents`](../type-aliases/NeuroLinkEvents.md)\>
 
-Defined in: [neurolink.ts:12406](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12406)
+Defined in: [neurolink.ts:12412](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12412)
 
 Get the EventEmitter instance to listen to NeuroLink events for real-time monitoring and debugging.
 This method provides access to the internal event system that emits events during AI generation,
@@ -833,7 +833,7 @@ This method does not throw errors as it returns the internal EventEmitter
 
 > **hasPendingHITLConfirmation**(`confirmationId`): `boolean`
 
-Defined in: [neurolink.ts:12446](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12446)
+Defined in: [neurolink.ts:12452](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12452)
 
 Whether a HITL confirmation is still awaiting a response on THIS instance.
 
@@ -888,7 +888,7 @@ neurolink.getEventEmitter().emit("hitl:confirmation-response", { ... });
 
 > **getToolDedupConfig**(): [`ToolDedupConfig`](../type-aliases/ToolDedupConfig.md) \| `undefined`
 
-Defined in: [neurolink.ts:12462](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12462)
+Defined in: [neurolink.ts:12468](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12468)
 
 Returns the instance-level tool-dedup configuration, or `undefined` when
 toolDedup was not provided at construction time.
@@ -911,7 +911,7 @@ parameter through the full call stack.
 
 > **getToolsConfig**(): [`ToolConfig`](../type-aliases/ToolConfig.md) \| `undefined`
 
-Defined in: [neurolink.ts:12473](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12473)
+Defined in: [neurolink.ts:12479](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12479)
 
 Returns the instance-level `tools` config (master switch, include/exclude
 lists, discovery mode), or `undefined` when not provided at construction.
@@ -929,7 +929,7 @@ instance policy with per-call options on every generate/stream call.
 
 > **getDiscoveryPins**(`sessionKey`): `ReadonlySet`\<`string`\>
 
-Defined in: [neurolink.ts:12484](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12484)
+Defined in: [neurolink.ts:12490](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12490)
 
 Tools discovered via `search_tools` for a session (`tools.discovery`
 mode). Pinned tools are sent in full on every subsequent call of that
@@ -953,7 +953,7 @@ are never the ones evicted at the session cap.
 
 > **pinDiscoveredTools**(`sessionKey`, `toolNames`): `void`
 
-Defined in: [neurolink.ts:12501](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12501)
+Defined in: [neurolink.ts:12507](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12507)
 
 Pin discovered tools to a session (called by the `search_tools`
 meta-tool on hydration). Append-only within a session; the map is
@@ -979,7 +979,7 @@ bounded by evicting the least-recently-used session past 1000 sessions.
 
 > **checkCredentials**(`input`): `Promise`\<\{ `provider`: `string`; `status`: `"network"` \| `"expired"` \| `"unknown"` \| `"ok"` \| `"missing"` \| `"denied"`; `detail`: `string`; \}\>
 
-Defined in: [neurolink.ts:12546](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12546)
+Defined in: [neurolink.ts:12552](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12552)
 
 Curator P1-1: synchronous credential health check for a single provider.
 
@@ -1031,7 +1031,7 @@ if (health.status !== "ok") {
 
 > **emitToolStart**(`toolName`, `input`, `startTime?`): `string`
 
-Defined in: [neurolink.ts:12625](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12625)
+Defined in: [neurolink.ts:12631](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12631)
 
 Emit tool start event with execution tracking
 
@@ -1067,7 +1067,7 @@ executionId for tracking this specific execution
 
 > **emitToolEnd**(`toolName`, `result?`, `error?`, `startTime?`, `endTime?`, `executionId?`): `void`
 
-Defined in: [neurolink.ts:12676](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12676)
+Defined in: [neurolink.ts:12682](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12682)
 
 Emit tool end event with execution summary
 
@@ -1119,7 +1119,7 @@ Optional execution ID for tracking
 
 > **getCurrentToolExecutions**(): [`ToolExecutionContext`](../type-aliases/ToolExecutionContext.md)[]
 
-Defined in: [neurolink.ts:12757](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12757)
+Defined in: [neurolink.ts:12763](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12763)
 
 Get current tool execution contexts for stream metadata
 
@@ -1133,7 +1133,7 @@ Get current tool execution contexts for stream metadata
 
 > **getToolExecutionHistory**(): [`ToolExecutionSummary`](../type-aliases/ToolExecutionSummary.md)[]
 
-Defined in: [neurolink.ts:12764](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12764)
+Defined in: [neurolink.ts:12770](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12770)
 
 Get tool execution history
 
@@ -1147,7 +1147,7 @@ Get tool execution history
 
 > **clearCurrentStreamExecutions**(): `void`
 
-Defined in: [neurolink.ts:12771](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12771)
+Defined in: [neurolink.ts:12777](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12777)
 
 Clear current stream tool executions (called at stream start)
 
@@ -1161,7 +1161,7 @@ Clear current stream tool executions (called at stream start)
 
 > **registerTool**(`name`, `tool`, `options?`): `void`
 
-Defined in: [neurolink.ts:12787](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12787)
+Defined in: [neurolink.ts:12793](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12793)
 
 Register a custom tool that will be available to all AI providers
 
@@ -1207,7 +1207,7 @@ Tool in MCPExecutableTool format (unified MCP protocol type)
 
 > **setToolContext**(`context`): `void`
 
-Defined in: [neurolink.ts:12938](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12938)
+Defined in: [neurolink.ts:12944](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12944)
 
 Set the context that will be passed to tools during execution
 This context will be merged with any runtime context passed by the AI model
@@ -1230,7 +1230,7 @@ Context object containing session info, tokens, shop data, etc.
 
 > **getToolContext**(): `Record`\<`string`, `unknown`\> \| `undefined`
 
-Defined in: [neurolink.ts:12953](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12953)
+Defined in: [neurolink.ts:12959](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12959)
 
 Get the current tool execution context
 
@@ -1246,7 +1246,7 @@ Current context or undefined if not set
 
 > **clearToolContext**(): `void`
 
-Defined in: [neurolink.ts:12962](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12962)
+Defined in: [neurolink.ts:12968](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12968)
 
 Clear the tool execution context
 
@@ -1260,7 +1260,7 @@ Clear the tool execution context
 
 > **registerTools**(`tools`): `void`
 
-Defined in: [neurolink.ts:12974](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12974)
+Defined in: [neurolink.ts:12980](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12980)
 
 Register multiple tools at once - Supports both object and array formats
 
@@ -1285,7 +1285,7 @@ Array format (Lighthouse compatible): [{ name: string, tool: MCPExecutableTool }
 
 > **unregisterTool**(`name`): `boolean`
 
-Defined in: [neurolink.ts:12997](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12997)
+Defined in: [neurolink.ts:13003](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13003)
 
 Unregister a custom tool
 
@@ -1309,7 +1309,7 @@ true if the tool was removed, false if it didn't exist
 
 > **useToolMiddleware**(`middleware`): `this`
 
-Defined in: [neurolink.ts:13016](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13016)
+Defined in: [neurolink.ts:13022](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13022)
 
 Register a global tool middleware that runs on every tool execution.
 Middleware receives the tool, params, context, and a next() function.
@@ -1334,7 +1334,7 @@ this (for chaining)
 
 > **getToolMiddlewares**(): [`ToolMiddleware`](../type-aliases/ToolMiddleware.md)[]
 
-Defined in: [neurolink.ts:13029](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13029)
+Defined in: [neurolink.ts:13035](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13035)
 
 Get all registered tool middlewares
 
@@ -1348,7 +1348,7 @@ Get all registered tool middlewares
 
 > **flushToolBatch**(): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:13036](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13036)
+Defined in: [neurolink.ts:13042](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13042)
 
 Flush any pending batched tool calls immediately
 
@@ -1362,7 +1362,7 @@ Flush any pending batched tool calls immediately
 
 > **getMCPEnhancementsConfig**(): [`MCPEnhancementsConfig`](../type-aliases/MCPEnhancementsConfig.md) \| `undefined`
 
-Defined in: [neurolink.ts:13045](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13045)
+Defined in: [neurolink.ts:13051](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13051)
 
 Get the current MCP enhancements configuration
 
@@ -1376,7 +1376,7 @@ Get the current MCP enhancements configuration
 
 > **updateAgenticLoopReport**(`sessionId`, `report`, `userId?`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:13068](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13068)
+Defined in: [neurolink.ts:13074](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13074)
 
 Update agentic loop report metadata for a conversation session.
 Upserts a report entry by reportId — updates existing or adds new.
@@ -1426,7 +1426,7 @@ await neurolink.updateAgenticLoopReport("session-123", {
 
 > **getCustomTools**(): `Map`\<`string`, \{ `name`: `string`; `description`: `string`; `inputSchema?`: `object`; `execute?`: (`params`, `context?`) => `unknown`; \}\>
 
-Defined in: [neurolink.ts:13104](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13104)
+Defined in: [neurolink.ts:13110](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13110)
 
 Get all registered custom tools
 
@@ -1442,7 +1442,7 @@ Map of tool names to MCPExecutableTool format
 
 > **addInMemoryMCPServer**(`serverId`, `serverInfo`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:13242](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13242)
+Defined in: [neurolink.ts:13248](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13248)
 
 Add an in-memory MCP server (from git diff)
 Allows registration of pre-instantiated server objects
@@ -1471,7 +1471,7 @@ Server configuration
 
 > **getInMemoryServers**(): `Map`\<`string`, [`MCPServerInfo`](../type-aliases/MCPServerInfo.md)\>
 
-Defined in: [neurolink.ts:13286](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13286)
+Defined in: [neurolink.ts:13292](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13292)
 
 Get all registered in-memory servers as a Map for ID-based lookup.
 
@@ -1494,7 +1494,7 @@ Map of server IDs to MCPServerInfo
 
 > **getInMemoryServerInfos**(): [`MCPServerInfo`](../type-aliases/MCPServerInfo.md)[]
 
-Defined in: [neurolink.ts:13313](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13313)
+Defined in: [neurolink.ts:13319](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13319)
 
 Get in-memory servers as an array of MCPServerInfo.
 
@@ -1524,7 +1524,7 @@ Array of MCPServerInfo for in-memory servers
 
 > **getAutoDiscoveredServerInfos**(): [`MCPServerInfo`](../type-aliases/MCPServerInfo.md)[]
 
-Defined in: [neurolink.ts:13329](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13329)
+Defined in: [neurolink.ts:13335](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13335)
 
 Get auto-discovered servers as MCPServerInfo - ZERO conversion needed
 
@@ -1540,7 +1540,7 @@ Array of MCPServerInfo
 
 > **executeTool**\<`T`\>(`toolName`, `params?`, `options?`): `Promise`\<`T`\>
 
-Defined in: [neurolink.ts:13341](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13341)
+Defined in: [neurolink.ts:13347](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13347)
 
 Execute a specific tool by name with robust error handling
 Supports both custom tools and MCP server tools with timeout, retry, and circuit breaker patterns
@@ -1631,7 +1631,7 @@ Tool execution result
 
 > **getAllAvailableTools**(): `Promise`\<[`ToolInfo`](../type-aliases/ToolInfo.md)[]\>
 
-Defined in: [neurolink.ts:14441](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14441)
+Defined in: [neurolink.ts:14447](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14447)
 
 ##### Returns
 
@@ -1643,7 +1643,7 @@ Defined in: [neurolink.ts:14441](https://github.com/juspay/neurolink/blob/releas
 
 > **getProviderStatus**(`options?`): `Promise`\<[`ProviderStatus`](../type-aliases/ProviderStatus.md)[]\>
 
-Defined in: [neurolink.ts:14623](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14623)
+Defined in: [neurolink.ts:14629](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14629)
 
 Get comprehensive status of all AI providers
 Primary method for provider health checking and diagnostics
@@ -1666,7 +1666,7 @@ Primary method for provider health checking and diagnostics
 
 > **testProvider**(`providerName`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:14804](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14804)
+Defined in: [neurolink.ts:14810](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14810)
 
 Test a specific AI provider's connectivity and authentication
 
@@ -1690,7 +1690,7 @@ Promise resolving to true if provider is working
 
 > **getBestProvider**(`requestedProvider?`): `Promise`\<`string`\>
 
-Defined in: [neurolink.ts:14836](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14836)
+Defined in: [neurolink.ts:14842](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14842)
 
 Get the best available AI provider based on configuration and availability
 
@@ -1714,7 +1714,7 @@ Promise resolving to the best provider name
 
 > **getAvailableProviders**(): `Promise`\<`string`[]\>
 
-Defined in: [neurolink.ts:14845](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14845)
+Defined in: [neurolink.ts:14851](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14851)
 
 Get list of all available AI provider names
 
@@ -1730,7 +1730,7 @@ Array of supported provider names
 
 > **isValidProvider**(`providerName`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:14855](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14855)
+Defined in: [neurolink.ts:14861](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14861)
 
 Validate if a provider name is supported
 
@@ -1754,7 +1754,7 @@ True if provider name is valid
 
 > **getMCPStatus**(): `Promise`\<[`MCPStatus`](../type-aliases/MCPStatus.md)\>
 
-Defined in: [neurolink.ts:14868](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14868)
+Defined in: [neurolink.ts:14874](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14874)
 
 Get comprehensive MCP (Model Context Protocol) status information
 
@@ -1770,7 +1770,7 @@ Promise resolving to MCP status details
 
 > **listMCPServers**(): `Promise`\<[`MCPServerInfo`](../type-aliases/MCPServerInfo.md)[]\>
 
-Defined in: [neurolink.ts:14938](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14938)
+Defined in: [neurolink.ts:14944](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14944)
 
 List all configured MCP servers with their status
 
@@ -1786,7 +1786,7 @@ Promise resolving to array of MCP server information
 
 > **testMCPServer**(`serverId`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:14953](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14953)
+Defined in: [neurolink.ts:14959](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14959)
 
 Test connectivity to a specific MCP server
 
@@ -1810,7 +1810,7 @@ Promise resolving to true if server is reachable
 
 > **hasProviderEnvVars**(`providerName`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:14994](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14994)
+Defined in: [neurolink.ts:15000](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15000)
 
 Check if a provider has the required environment variables configured
 
@@ -1834,7 +1834,7 @@ Promise resolving to true if provider has required env vars
 
 > **checkProviderHealth**(`providerName`, `options?`): `Promise`\<\{ `provider`: `string`; `isHealthy`: `boolean`; `isConfigured`: `boolean`; `hasApiKey`: `boolean`; `lastChecked`: `Date`; `error?`: `string`; `warning?`: `string`; `responseTime?`: `number`; `configurationIssues`: `string`[]; `recommendations`: `string`[]; \}\>
 
-Defined in: [neurolink.ts:15020](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15020)
+Defined in: [neurolink.ts:15026](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15026)
 
 Perform comprehensive health check on a specific provider
 
@@ -1878,7 +1878,7 @@ Promise resolving to detailed health status
 
 > **checkAllProvidersHealth**(`options?`): `Promise`\<`object`[]\>
 
-Defined in: [neurolink.ts:15066](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15066)
+Defined in: [neurolink.ts:15072](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15072)
 
 Check health of all supported providers
 
@@ -1916,7 +1916,7 @@ Promise resolving to array of health statuses for all providers
 
 > **getProviderHealthSummary**(): `Promise`\<\{ `total`: `number`; `healthy`: `number`; `configured`: `number`; `hasIssues`: `number`; `healthyProviders`: `string`[]; `unhealthyProviders`: `string`[]; `recommendations`: `string`[]; \}\>
 
-Defined in: [neurolink.ts:15110](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15110)
+Defined in: [neurolink.ts:15116](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15116)
 
 Get a summary of provider health across all supported providers
 
@@ -1932,7 +1932,7 @@ Promise resolving to health summary statistics
 
 > **clearProviderHealthCache**(`providerName?`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:15157](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15157)
+Defined in: [neurolink.ts:15163](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15163)
 
 Clear provider health cache (useful for re-testing after configuration changes)
 
@@ -1954,7 +1954,7 @@ Optional specific provider to clear cache for
 
 > **getToolExecutionMetrics**(): `Record`\<`string`, \{ `totalExecutions`: `number`; `successfulExecutions`: `number`; `failedExecutions`: `number`; `successRate`: `number`; `averageExecutionTime`: `number`; `lastExecutionTime`: `number`; `errorCategories`: `Record`\<`string`, `number`\>; \}\>
 
-Defined in: [neurolink.ts:15168](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15168)
+Defined in: [neurolink.ts:15174](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15174)
 
 Get execution metrics for all tools
 
@@ -1970,7 +1970,7 @@ Object with execution metrics for each tool
 
 > **setModelAliasConfig**(`config`): `void`
 
-Defined in: [neurolink.ts:15212](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15212)
+Defined in: [neurolink.ts:15218](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15218)
 
 NL-004: Set model alias/deprecation configuration.
 Models in the alias map will be warned, redirected, or blocked based on their action.
@@ -1993,7 +1993,7 @@ Model alias configuration with aliases map
 
 > **getToolCircuitBreakerStatus**(): `Record`\<`string`, \{ `state`: `"closed"` \| `"open"` \| `"half-open"`; `failureCount`: `number`; `isHealthy`: `boolean`; \}\>
 
-Defined in: [neurolink.ts:15225](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15225)
+Defined in: [neurolink.ts:15231](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15231)
 
 Get circuit breaker status for all tools
 
@@ -2009,7 +2009,7 @@ Object with circuit breaker status for each tool
 
 > **resetToolCircuitBreaker**(`toolName`): `void`
 
-Defined in: [neurolink.ts:15260](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15260)
+Defined in: [neurolink.ts:15266](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15266)
 
 Reset circuit breaker for a specific tool
 
@@ -2031,7 +2031,7 @@ Name of the tool to reset circuit breaker for
 
 > **clearToolExecutionMetrics**(): `void`
 
-Defined in: [neurolink.ts:15277](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15277)
+Defined in: [neurolink.ts:15283](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15283)
 
 Clear all tool execution metrics
 
@@ -2045,7 +2045,7 @@ Clear all tool execution metrics
 
 > **getToolHealthReport**(): `Promise`\<\{ `totalTools`: `number`; `healthyTools`: `number`; `unhealthyTools`: `number`; `tools`: `Record`\<`string`, \{ `name`: `string`; `isHealthy`: `boolean`; `metrics`: \{ `totalExecutions`: `number`; `successRate`: `number`; `averageExecutionTime`: `number`; `lastExecutionTime`: `number`; `errorCategories`: `Record`\<`string`, `number`\>; \}; `circuitBreaker`: \{ `state`: `"closed"` \| `"open"` \| `"half-open"`; `failureCount`: `number`; \}; `issues`: `string`[]; `recommendations`: `string`[]; \}\>; \}\>
 
-Defined in: [neurolink.ts:15286](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15286)
+Defined in: [neurolink.ts:15292](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15292)
 
 Get comprehensive tool health report
 
@@ -2061,7 +2061,7 @@ Detailed health report for all tools
 
 > **ensureConversationMemoryInitialized**(): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:15441](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15441)
+Defined in: [neurolink.ts:15447](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15447)
 
 Initialize conversation memory if enabled (public method for explicit initialization)
 This is useful for testing or when you want to ensure conversation memory is ready
@@ -2078,7 +2078,7 @@ Promise resolving to true if initialization was successful, false otherwise
 
 > **getConversationStats**(): `Promise`\<[`ConversationMemoryStats`](../type-aliases/ConversationMemoryStats.md)\>
 
-Defined in: [neurolink.ts:15461](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15461)
+Defined in: [neurolink.ts:15467](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15467)
 
 Get conversation memory statistics (public API)
 
@@ -2092,7 +2092,7 @@ Get conversation memory statistics (public API)
 
 > **getConversationHistory**(`sessionId`): `Promise`\<[`ChatMessage`](../type-aliases/ChatMessage.md)[]\>
 
-Defined in: [neurolink.ts:15488](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15488)
+Defined in: [neurolink.ts:15494](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15494)
 
 Get complete conversation history for a specific session (public API)
 
@@ -2116,7 +2116,7 @@ Array of ChatMessage objects in chronological order, or empty array if session d
 
 > **clearConversationSession**(`sessionId`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:15544](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15544)
+Defined in: [neurolink.ts:15550](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15550)
 
 Clear conversation history for a specific session (public API)
 
@@ -2136,7 +2136,7 @@ Clear conversation history for a specific session (public API)
 
 > **clearAllConversations**(): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:15570](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15570)
+Defined in: [neurolink.ts:15576](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15576)
 
 Clear all conversation history (public API)
 
@@ -2150,7 +2150,7 @@ Clear all conversation history (public API)
 
 > **listSessions**(`userId?`): `Promise`\<[`SessionListItem`](../type-aliases/SessionListItem.md)[]\>
 
-Defined in: [neurolink.ts:15598](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15598)
+Defined in: [neurolink.ts:15604](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15604)
 
 List all conversation sessions with metadata (public API)
 
@@ -2174,7 +2174,7 @@ Array of session list items with metadata
 
 > **exportSession**(`sessionId`, `options?`): `Promise`\<[`SessionExport`](../type-aliases/SessionExport.md) \| `null`\>
 
-Defined in: [neurolink.ts:15647](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15647)
+Defined in: [neurolink.ts:15653](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15653)
 
 Export a single session with full history and metadata (public API)
 
@@ -2210,7 +2210,7 @@ Session export object with full history
 
 > **exportAllSessions**(`userId?`, `options?`): `Promise`\<[`SessionExport`](../type-aliases/SessionExport.md)[]\>
 
-Defined in: [neurolink.ts:15732](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15732)
+Defined in: [neurolink.ts:15738](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15738)
 
 Export all sessions for a user (public API)
 
@@ -2246,7 +2246,7 @@ Array of session exports
 
 > **storeToolExecutions**(`sessionId`, `userId`, `toolCalls`, `toolResults`, `currentTime?`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:15796](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15796)
+Defined in: [neurolink.ts:15802](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15802)
 
 Store tool executions in conversation memory if enabled and Redis is configured
 
@@ -2294,7 +2294,7 @@ Promise resolving when storage is complete
 
 > **isToolExecutionStorageAvailable**(): `boolean`
 
-Defined in: [neurolink.ts:15866](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15866)
+Defined in: [neurolink.ts:15872](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15872)
 
 Check if tool execution storage is available.
 
@@ -2315,7 +2315,7 @@ whether the active memory backend can persist tool executions
 
 > **getSessionMessages**(`sessionId`, `userId?`): `Promise`\<[`ChatMessage`](../type-aliases/ChatMessage.md)[]\>
 
-Defined in: [neurolink.ts:15876](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15876)
+Defined in: [neurolink.ts:15882](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15882)
 
 Get the raw messages array for a session.
 Returns the full messages list without context filtering or summarization.
@@ -2344,7 +2344,7 @@ Array of ChatMessage objects, or empty array if session doesn't exist
 
 > **setSessionMessages**(`sessionId`, `messages`, `userId?`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:15917](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15917)
+Defined in: [neurolink.ts:15923](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15923)
 
 Replace the entire messages array for a session.
 
@@ -2378,7 +2378,7 @@ Optional user ID for scoped Redis key lookup
 
 > **modifyLastAssistantMessage**(`sessionId`, `transformer`, `userId?`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:15965](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15965)
+Defined in: [neurolink.ts:15971](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15971)
 
 Modify the last assistant message in a session using a transformer function.
 Convenience wrapper around getSessionMessages/setSessionMessages.
@@ -2415,7 +2415,7 @@ true if a message was modified, false if no assistant message was found
 
 > **addExternalMCPServer**(`serverId`, `config`): `Promise`\<[`ExternalMCPOperationResult`](../type-aliases/ExternalMCPOperationResult.md)\<[`ExternalMCPServerInstance`](../type-aliases/ExternalMCPServerInstance.md)\>\>
 
-Defined in: [neurolink.ts:15996](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15996)
+Defined in: [neurolink.ts:16002](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16002)
 
 Add an external MCP server
 Automatically discovers and registers tools from the server
@@ -2446,7 +2446,7 @@ Operation result with server instance
 
 > **removeExternalMCPServer**(`serverId`): `Promise`\<[`ExternalMCPOperationResult`](../type-aliases/ExternalMCPOperationResult.md)\<`void`\>\>
 
-Defined in: [neurolink.ts:16083](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16083)
+Defined in: [neurolink.ts:16089](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16089)
 
 Remove an external MCP server
 Stops the server and removes all its tools
@@ -2471,7 +2471,7 @@ Operation result
 
 > **listExternalMCPServers**(): `object`[]
 
-Defined in: [neurolink.ts:16135](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16135)
+Defined in: [neurolink.ts:16141](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16141)
 
 List all external MCP servers
 
@@ -2487,7 +2487,7 @@ Array of server health information
 
 > **getExternalMCPServer**(`serverId`): [`ExternalMCPServerInstance`](../type-aliases/ExternalMCPServerInstance.md) \| `undefined`
 
-Defined in: [neurolink.ts:16164](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16164)
+Defined in: [neurolink.ts:16170](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16170)
 
 Get external MCP server status
 
@@ -2511,7 +2511,7 @@ Server instance or undefined if not found
 
 > **executeExternalMCPTool**(`serverId`, `requestedToolName`, `parameters`, `options?`): `Promise`\<`unknown`\>
 
-Defined in: [neurolink.ts:16178](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16178)
+Defined in: [neurolink.ts:16184](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16184)
 
 Execute a tool from an external MCP server
 
@@ -2553,7 +2553,7 @@ Tool execution result
 
 > **getExternalMCPTools**(): [`ExternalMCPToolInfo`](../type-aliases/ExternalMCPToolInfo.md)[]
 
-Defined in: [neurolink.ts:16377](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16377)
+Defined in: [neurolink.ts:16383](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16383)
 
 Get all tools from external MCP servers
 
@@ -2569,7 +2569,7 @@ Array of external tool information
 
 > **getExternalMCPServerTools**(`serverId`): [`ExternalMCPToolInfo`](../type-aliases/ExternalMCPToolInfo.md)[]
 
-Defined in: [neurolink.ts:16386](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16386)
+Defined in: [neurolink.ts:16392](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16392)
 
 Get tools from a specific external MCP server
 
@@ -2593,7 +2593,7 @@ Array of tool information for the server
 
 > **testExternalMCPConnection**(`config`): `Promise`\<[`BatchOperationResult`](../type-aliases/BatchOperationResult.md)\>
 
-Defined in: [neurolink.ts:16395](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16395)
+Defined in: [neurolink.ts:16401](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16401)
 
 Test connection to an external MCP server
 
@@ -2617,7 +2617,7 @@ Test result with connection status
 
 > **getExternalMCPStatistics**(): `object`
 
-Defined in: [neurolink.ts:16423](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16423)
+Defined in: [neurolink.ts:16429](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16429)
 
 Get external MCP server manager statistics
 
@@ -2657,7 +2657,7 @@ Statistics about external servers and tools
 
 > **shutdownExternalMCPServers**(): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:16438](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16438)
+Defined in: [neurolink.ts:16444](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16444)
 
 Shutdown all external MCP servers
 Called automatically on process exit
@@ -2672,7 +2672,7 @@ Called automatically on process exit
 
 > **getElicitationManager**(): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16476](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16476)
+Defined in: [neurolink.ts:16482](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16482)
 
 Get the global elicitation manager for interactive tool input
 Elicitation allows tools to request additional information from users during execution
@@ -2703,7 +2703,7 @@ elicitationManager.registerHandler(async (request) => {
 
 > **registerElicitationHandler**(`handler`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:16504](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16504)
+Defined in: [neurolink.ts:16510](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16510)
 
 Register an elicitation handler for interactive tool input
 Handlers are called when tools need user input during execution
@@ -2741,7 +2741,7 @@ neurolink.registerElicitationHandler(async (request) => {
 
 > **getMultiServerManager**(): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16527](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16527)
+Defined in: [neurolink.ts:16533](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16533)
 
 Get the multi-server manager for load balancing and coordination
 Allows managing multiple MCP servers with failover and load balancing
@@ -2770,7 +2770,7 @@ await multiServer.createServerGroup("ai-tools", {
 
 > **getEnhancedToolDiscovery**(): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16552](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16552)
+Defined in: [neurolink.ts:16558](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16558)
 
 Get the enhanced tool discovery service
 Provides advanced search, filtering, and compatibility checking for tools
@@ -2800,7 +2800,7 @@ const results = await discovery.searchTools({
 
 > **getMCPRegistryClient**(): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16579](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16579)
+Defined in: [neurolink.ts:16585](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16585)
 
 Get the MCP registry client for discovering servers from registries
 Supports multiple registry sources (official, community, custom)
@@ -2832,7 +2832,7 @@ const githubServer = registryClient.getWellKnownServer("github");
 
 > **exposeAgentAsTool**(`agent`, `options?`): `Promise`\<[`ExposureResult`](../type-aliases/ExposureResult.md)\>
 
-Defined in: [neurolink.ts:16607](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16607)
+Defined in: [neurolink.ts:16613](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16613)
 
 Expose a NeuroLink agent as an MCP tool
 This allows agents to be called by other systems via MCP
@@ -2909,7 +2909,7 @@ const tool = await neurolink.exposeAgentAsTool(agent, {
 
 > **exposeWorkflowAsTool**(`workflow`, `options?`): `Promise`\<[`ExposureResult`](../type-aliases/ExposureResult.md)\>
 
-Defined in: [neurolink.ts:16648](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16648)
+Defined in: [neurolink.ts:16654](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16654)
 
 Expose a workflow as an MCP tool
 This allows workflows to be called by other systems via MCP
@@ -2990,7 +2990,7 @@ const tool = await neurolink.exposeWorkflowAsTool(workflow, {
 
 > **getToolIntegrationManager**(): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16687](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16687)
+Defined in: [neurolink.ts:16693](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16693)
 
 Get the tool integration manager for middleware and elicitation
 Provides advanced tool wrapping with confirmation, timeout, retry, etc.
@@ -3020,7 +3020,7 @@ integration.registerTool(myTool, {
 
 > **convertToolsToMCPFormat**(`tools`, `options?`): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16709](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16709)
+Defined in: [neurolink.ts:16715](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16715)
 
 Convert NeuroLink tools to MCP format
 Useful for exposing local tools to external MCP clients
@@ -3061,7 +3061,7 @@ const mcpTools = neurolink.convertToolsToMCPFormat([
 
 > **convertToolsFromMCPFormat**(`tools`, `options?`): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16748](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16748)
+Defined in: [neurolink.ts:16754](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16754)
 
 Convert MCP tools to NeuroLink format
 Useful for importing tools from external MCP servers
@@ -3102,7 +3102,7 @@ const neurolinkTools = neurolink.convertToolsFromMCPFormat(externalTools, {
 
 > **getToolAnnotations**(`toolName`): `Promise`\<\{ `annotations`: [`MCPToolAnnotations`](../type-aliases/MCPToolAnnotations.md); `summary`: `string`; \} \| `null`\>
 
-Defined in: [neurolink.ts:16771](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16771)
+Defined in: [neurolink.ts:16777](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16777)
 
 Get tool annotations and safety information
 Provides insights about tool behavior, safety levels, and retry-ability
@@ -3134,7 +3134,7 @@ const annotations = await neurolink.getToolAnnotations("deleteFile");
 
 > **createEvaluationPipeline**(`configOrPreset`): `Promise`\<[`EvaluationPipeline`](EvaluationPipeline.md)\>
 
-Defined in: [neurolink.ts:17010](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17010)
+Defined in: [neurolink.ts:17016](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17016)
 
 Create an evaluation pipeline with the specified configuration or preset.
 Pipelines orchestrate multiple scorers to evaluate AI responses comprehensively.
@@ -3185,7 +3185,7 @@ const pipeline = await neurolink.createEvaluationPipeline({
 
 > **evaluate**(`input`, `options?`): `Promise`\<[`PipelineResult`](../type-aliases/PipelineResult.md)\>
 
-Defined in: [neurolink.ts:17102](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17102)
+Defined in: [neurolink.ts:17108](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17108)
 
 Evaluate an AI response using the specified pipeline or scorers.
 This is a convenience method that creates a pipeline and executes it in one call.
@@ -3287,7 +3287,7 @@ const result = await neurolink.evaluate(
 
 > **score**(`scorerId`, `input`, `config?`): `Promise`\<[`ScoreResult`](../type-aliases/ScoreResult.md)\>
 
-Defined in: [neurolink.ts:17240](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17240)
+Defined in: [neurolink.ts:17246](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17246)
 
 Score a response using a single scorer.
 Useful for quick, targeted evaluations without the overhead of a full pipeline.
@@ -3356,7 +3356,7 @@ const result = await neurolink.score(
 
 > **getAvailableScorers**(`options?`): `Promise`\<[`ScorerMetadata`](../type-aliases/ScorerMetadata.md)[]\>
 
-Defined in: [neurolink.ts:17326](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17326)
+Defined in: [neurolink.ts:17332](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17332)
 
 Get a list of all available scorers and their metadata.
 Useful for discovering what evaluation capabilities are available.
@@ -3417,7 +3417,7 @@ const ruleBasedScorers = await neurolink.getAvailableScorers({
 
 > **getEvaluationPresets**(): `Promise`\<`string`[]\>
 
-Defined in: [neurolink.ts:17372](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17372)
+Defined in: [neurolink.ts:17378](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17378)
 
 Get a list of available evaluation pipeline presets.
 Presets are pre-configured pipelines for common evaluation scenarios.
@@ -3443,7 +3443,7 @@ console.log("Available presets:", presets);
 
 > **getEvaluationPreset**(`presetName`): `Promise`\<[`PipelineConfig`](../type-aliases/PipelineConfig.md)\>
 
-Defined in: [neurolink.ts:17395](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17395)
+Defined in: [neurolink.ts:17401](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17401)
 
 Get details of a specific evaluation preset.
 
@@ -3479,7 +3479,7 @@ console.log("Pass threshold:", ragPreset.passThreshold);
 
 > **createAgent**(`definition`): `Promise`\<[`Agent`](Agent.md)\>
 
-Defined in: [neurolink.ts:17445](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17445)
+Defined in: [neurolink.ts:17451](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17451)
 
 Create an Agent instance for multi-agent orchestration.
 
@@ -3531,7 +3531,7 @@ const result = await researcher.execute("Find recent AI breakthroughs");
 
 > **createNetwork**(`config`): `Promise`\<[`AgentNetwork`](AgentNetwork.md)\>
 
-Defined in: [neurolink.ts:17507](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17507)
+Defined in: [neurolink.ts:17513](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17513)
 
 Create an AgentNetwork for multi-agent orchestration.
 
@@ -3605,7 +3605,7 @@ const result = await network.execute({
 
 > **createWorkerInstance**(`options?`): `NeuroLink`
 
-Defined in: [neurolink.ts:17539](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17539)
+Defined in: [neurolink.ts:17545](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17545)
 
 Create a worker-mode NeuroLink instance for sub-agent execution.
 
@@ -3645,7 +3645,7 @@ A new worker-mode NeuroLink instance
 
 > **runIsolatedAgent**(`definition`, `input`, `options?`): `Promise`\<[`AgentRunOutcome`](../type-aliases/AgentRunOutcome.md)\>
 
-Defined in: [neurolink.ts:17638](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17638)
+Defined in: [neurolink.ts:17644](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17644)
 
 Run an isolated sub-agent: a worker instance (see
 [createWorkerInstance](#createworkerinstance)) executes a tool-using research pass under
@@ -3695,7 +3695,7 @@ The run outcome
 
 > **continueAgent**(`handle`, `guidance?`): `Promise`\<[`AgentRunOutcome`](../type-aliases/AgentRunOutcome.md)\>
 
-Defined in: [neurolink.ts:17657](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17657)
+Defined in: [neurolink.ts:17663](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17663)
 
 Resume a leashed isolated-agent run by handle. `guidance`, when given,
 is appended as a user turn before the next leg — the supervisor's
@@ -3728,7 +3728,7 @@ The next leg's outcome (or the final outcome)
 
 > **stopAgent**(`handle`): `Promise`\<[`AgentRunOutcome`](../type-aliases/AgentRunOutcome.md)\>
 
-Defined in: [neurolink.ts:17673](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17673)
+Defined in: [neurolink.ts:17679](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17679)
 
 Stop a leashed isolated-agent run: dispose its worker and return the
 final outcome (mechanical digest over everything gathered so far).
@@ -3753,7 +3753,7 @@ The final outcome
 
 > **registerAgentTool**(`definition`, `options?`): `Promise`\<\{ `name`: `string`; \}\>
 
-Defined in: [neurolink.ts:17691](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17691)
+Defined in: [neurolink.ts:17697](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17697)
 
 Register an isolated agent as a delegation tool on THIS instance, so
 its existing generate() loop can delegate — no second router generate.
@@ -3791,7 +3791,7 @@ The registered tool name
 
 > **registerTaskTools**(): `void`
 
-Defined in: [neurolink.ts:17724](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17724)
+Defined in: [neurolink.ts:17730](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17730)
 
 Register the task CHECKLIST toolset — `tasks_create`, `tasks_update`,
 `tasks_list` — on this instance (TodoWrite-style planning for a
@@ -3827,7 +3827,7 @@ id for that one call.
 
 > **getTaskState**(`sessionId?`): [`ChecklistState`](../type-aliases/ChecklistState.md)
 
-Defined in: [neurolink.ts:17750](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17750)
+Defined in: [neurolink.ts:17756](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17756)
 
 Read a session's task checklist — synchronous, so a completeness gate is
 one line of host code:
@@ -3853,7 +3853,7 @@ instance's tool-context session, or its default checklist).
 
 > **clearTaskState**(`sessionId?`): `boolean`
 
-Defined in: [neurolink.ts:17758](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17758)
+Defined in: [neurolink.ts:17764](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17764)
 
 Drop a session's checklist. Returns whether there was one to drop.
 Omit `sessionId` to clear the session the tools currently write to.
@@ -3874,7 +3874,7 @@ Omit `sessionId` to clear the session the tools currently write to.
 
 > **registerDelegationTools**(`options?`): `void`
 
-Defined in: [neurolink.ts:17785](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17785)
+Defined in: [neurolink.ts:17791](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17791)
 
 Register the background-delegation toolset — `delegate_task` and
 `collect_results` — on this instance. Opt-in and idempotent: existing
@@ -3913,7 +3913,7 @@ Depth ceiling, pool raise, and queue wait
 
 > **spawnDelegate**(`options`): `Promise`\<[`DelegateHandle`](../type-aliases/DelegateHandle.md)\>
 
-Defined in: [neurolink.ts:17825](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17825)
+Defined in: [neurolink.ts:17831](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17831)
 
 Start a background worker and get its handle immediately — before it has
 run anything, and long before it finishes.
@@ -3957,7 +3957,7 @@ when the task is empty or the caller is at the depth ceiling
 
 > **collectDelegates**(`request`): `Promise`\<[`DelegateCollectResult`](../type-aliases/DelegateCollectResult.md)\>
 
-Defined in: [neurolink.ts:17836](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17836)
+Defined in: [neurolink.ts:17842](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17842)
 
 Claim finished background workers — in COMPLETION order, which has nothing
 to do with spawn order. Each outcome is handed out exactly once.
@@ -3982,7 +3982,7 @@ Claimed outcomes plus what is still pending/ready
 
 > **cancelDelegates**(`workerId?`): `Promise`\<`number`\>
 
-Defined in: [neurolink.ts:17850](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17850)
+Defined in: [neurolink.ts:17856](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17856)
 
 Cancel background workers: one by id, or every outstanding worker this
 instance spawned. Cancelled workers still settle into a claimable outcome
@@ -4008,7 +4008,7 @@ How many workers were cancelled
 
 > **getArtifactStore**(): [`ArtifactStore`](../type-aliases/ArtifactStore.md)
 
-Defined in: [neurolink.ts:17873](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17873)
+Defined in: [neurolink.ts:17879](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17879)
 
 This instance's artifact store, created on first use.
 
@@ -4034,7 +4034,7 @@ The artifact store backing [bankArtifact](#bankartifact) / [readArtifact](#reada
 
 > **setArtifactStore**(`store`): `void`
 
-Defined in: [neurolink.ts:17903](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17903)
+Defined in: [neurolink.ts:17909](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17909)
 
 Replace this instance's artifact store.
 
@@ -4072,7 +4072,7 @@ Any [ArtifactStore](../type-aliases/ArtifactStore.md)
 
 > **bankArtifact**(`payload`, `options`): `Promise`\<[`BankedArtifactRef`](../type-aliases/BankedArtifactRef.md)\>
 
-Defined in: [neurolink.ts:17991](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17991)
+Defined in: [neurolink.ts:17997](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17997)
 
 Bank a payload to a file and get back a pointer to it.
 
@@ -4119,7 +4119,7 @@ const ref = await neurolink.bankArtifact(fullReport, {
 
 > **readArtifact**(`id`, `page?`): `Promise`\<`string` \| `null`\>
 
-Defined in: [neurolink.ts:18008](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18008)
+Defined in: [neurolink.ts:18014](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18014)
 
 Read a banked payload back from host code — the programmatic twin of the
 model's `retrieve_context({ artifactId })` call.
@@ -4151,7 +4151,7 @@ Optional character window
 
 > **registerBackgroundCommandTools**(`policy`): `void`
 
-Defined in: [neurolink.ts:18040](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18040)
+Defined in: [neurolink.ts:18046](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18046)
 
 Register the background-command toolset — `run_command_bg`,
 `command_status`, `command_output`, `command_kill` — on this instance, and
@@ -4192,7 +4192,7 @@ What may run, where, for how long, and how loudly
 
 > **setBackgroundCommandPolicy**(`policy`): `void`
 
-Defined in: [neurolink.ts:18065](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18065)
+Defined in: [neurolink.ts:18071](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18071)
 
 Declare (or replace) what this instance may execute, without registering
 the model-facing tools. Host code that only drives
@@ -4216,7 +4216,7 @@ What may run, where, for how long, and how loudly
 
 > **startBackgroundCommand**(`argv`, `options`): `Promise`\<[`BackgroundCommandHandle`](../type-aliases/BackgroundCommandHandle.md)\>
 
-Defined in: [neurolink.ts:18089](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18089)
+Defined in: [neurolink.ts:18095](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18095)
 
 Start a command in the background and get its task id immediately.
 
@@ -4263,7 +4263,7 @@ allowlisted, the policy vetoes it, or the cwd escapes the sandbox
 
 > **getBackgroundCommandStatus**(`taskId`): [`BackgroundCommandStatus`](../type-aliases/BackgroundCommandStatus.md)
 
-Defined in: [neurolink.ts:18103](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18103)
+Defined in: [neurolink.ts:18109](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18109)
 
 Everything known about one command right now — synchronous, so a
 mid-loop monitor costs nothing.
@@ -4290,7 +4290,7 @@ when the task id is unknown to this instance
 
 > **awaitBackgroundCommand**(`taskId`, `opts?`): `Promise`\<[`BackgroundCommandStatus`](../type-aliases/BackgroundCommandStatus.md)\>
 
-Defined in: [neurolink.ts:18115](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18115)
+Defined in: [neurolink.ts:18121](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18121)
 
 Wait for a command to settle. `timeoutMs` bounds the WAIT, not the
 command: when it elapses the current status is returned rather than
@@ -4322,7 +4322,7 @@ Task id from [startBackgroundCommand](#startbackgroundcommand)
 
 > **killBackgroundCommand**(`taskId`, `signal?`): `Promise`\<[`BackgroundCommandStatus`](../type-aliases/BackgroundCommandStatus.md)\>
 
-Defined in: [neurolink.ts:18130](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18130)
+Defined in: [neurolink.ts:18136](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18136)
 
 Kill a running command — SIGTERM, then SIGKILL five seconds later — and
 resolve with its settled status. Whatever it printed first is still
@@ -4352,7 +4352,7 @@ Signal to send first. Default SIGTERM
 
 > **readBackgroundCommandOutput**(`taskId`, `page`): `Promise`\<[`BackgroundCommandOutputPage`](../type-aliases/BackgroundCommandOutputPage.md)\>
 
-Defined in: [neurolink.ts:18145](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18145)
+Defined in: [neurolink.ts:18151](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18151)
 
 Read one character window of a command's output straight from its log
 file — while it is still running, or long after it finished. Offsets,
@@ -4382,7 +4382,7 @@ Which stream, and which window of it
 
 > **registerGitTools**(`options`): `void`
 
-Defined in: [neurolink.ts:18172](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18172)
+Defined in: [neurolink.ts:18178](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18178)
 
 Register the read-only git toolset — `git_log`, `git_show`, `git_diff`,
 `git_blame`, `git_merge_base`, `git_ls_files` — on this instance. Opt-in
@@ -4415,7 +4415,7 @@ Repository root, plus timeout / byte-cap / preview bounds
 
 > **runGitCommand**(`args`, `sessionId?`): `Promise`\<[`GitToolResult`](../type-aliases/GitToolResult.md)\>
 
-Defined in: [neurolink.ts:18198](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18198)
+Defined in: [neurolink.ts:18204](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18204)
 
 Run one read-only git command from host code, with the same bounding the
 tools get: the complete stdout is banked, the result carries a preview and
@@ -4450,7 +4450,7 @@ when [registerGitTools](#registergittools) has not been called
 
 > **executeNetwork**(`network`, `input`, `options?`): `Promise`\<[`NetworkExecutionResult`](../type-aliases/NetworkExecutionResult.md)\>
 
-Defined in: [neurolink.ts:18217](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18217)
+Defined in: [neurolink.ts:18223](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18223)
 
 Execute an agent network with the given input.
 
@@ -4495,7 +4495,7 @@ Network execution result with content, trace, and usage
 
 > **streamNetwork**(`network`, `input`, `options?`): `AsyncIterable`\<[`NetworkStreamChunk`](../type-aliases/NetworkStreamChunk.md)\>
 
-Defined in: [neurolink.ts:18241](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18241)
+Defined in: [neurolink.ts:18247](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18247)
 
 Stream agent network execution with real-time events.
 
@@ -4539,7 +4539,7 @@ Async iterable of network stream chunks
 
 > **createOrchestrator**(`config?`): `Promise`\<[`NetworkOrchestrator`](NetworkOrchestrator.md)\>
 
-Defined in: [neurolink.ts:18265](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18265)
+Defined in: [neurolink.ts:18271](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18271)
 
 Create a NetworkOrchestrator for managing multiple agent networks.
 
@@ -4567,7 +4567,7 @@ A new NetworkOrchestrator instance
 
 > **createCoordinator**(`config?`): `Promise`\<[`AgentCoordinator`](AgentCoordinator.md)\>
 
-Defined in: [neurolink.ts:18284](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18284)
+Defined in: [neurolink.ts:18290](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18290)
 
 Create an AgentCoordinator for managing agent coordination strategies.
 
@@ -4595,7 +4595,7 @@ A new AgentCoordinator instance
 
 > **createMessageBus**(`config?`): `Promise`\<[`MessageBus`](MessageBus.md)\>
 
-Defined in: [neurolink.ts:18302](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18302)
+Defined in: [neurolink.ts:18308](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18308)
 
 Create a MessageBus for inter-agent communication.
 
@@ -4623,7 +4623,7 @@ A new MessageBus instance
 
 > **dispose**(): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:18317](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18317)
+Defined in: [neurolink.ts:18323](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18323)
 
 Dispose of all resources and cleanup connections
 Call this method when done using the NeuroLink instance to prevent resource leaks
@@ -4639,7 +4639,7 @@ Especially important in test environments where multiple instances are created
 
 > **getToolRegistry**(): [`MCPToolRegistry`](MCPToolRegistry.md)
 
-Defined in: [neurolink.ts:18536](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18536)
+Defined in: [neurolink.ts:18542](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18542)
 
 Get the tool registry instance
 Used internally by server adapters for tool management
@@ -4656,7 +4656,7 @@ The MCPToolRegistry instance
 
 > **compactSession**(`sessionId`, `config?`): `Promise`\<[`CompactionResult`](../type-aliases/CompactionResult.md) \| `null`\>
 
-Defined in: [neurolink.ts:18544](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18544)
+Defined in: [neurolink.ts:18550](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18550)
 
 Manually trigger context compaction for a session.
 Runs the full 4-stage compaction pipeline.
@@ -4681,7 +4681,7 @@ Runs the full 4-stage compaction pipeline.
 
 > **getContextStats**(`sessionId`, `provider?`, `model?`): `Promise`\<\{ `estimatedInputTokens`: `number`; `availableInputTokens`: `number`; `usageRatio`: `number`; `shouldCompact`: `boolean`; `messageCount`: `number`; \} \| `null`\>
 
-Defined in: [neurolink.ts:18595](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18595)
+Defined in: [neurolink.ts:18601](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18601)
 
 Get context usage statistics for a session.
 Returns token counts, usage ratio, and breakdown by category.
@@ -4710,7 +4710,7 @@ Returns token counts, usage ratio, and breakdown by category.
 
 > **needsCompaction**(`sessionId`, `provider?`, `model?`): `boolean`
 
-Defined in: [neurolink.ts:18637](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18637)
+Defined in: [neurolink.ts:18643](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18643)
 
 Check if a session needs compaction.
 
@@ -4738,7 +4738,7 @@ Check if a session needs compaction.
 
 > **setAuthProvider**(`config`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:18674](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18674)
+Defined in: [neurolink.ts:18680](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18680)
 
 Set the authentication provider for the NeuroLink instance
 
@@ -4760,7 +4760,7 @@ Auth provider or configuration to create one
 
 > **getAuthProvider**(): [`AuthProvider`](../type-aliases/AuthProvider.md) \| `undefined`
 
-Defined in: [neurolink.ts:18722](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18722)
+Defined in: [neurolink.ts:18728](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18728)
 
 Get the currently configured authentication provider
 
@@ -4774,7 +4774,7 @@ Get the currently configured authentication provider
 
 > **setAuthContext**(`context`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:18763](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18763)
+Defined in: [neurolink.ts:18769](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18769)
 
 Set the current authentication context for request handling.
 
@@ -4801,7 +4801,7 @@ The authenticated user context
 
 > **getAuthContext**(): `Promise`\<[`AuthenticatedContext`](../type-aliases/AuthenticatedContext.md) \| `undefined`\>
 
-Defined in: [neurolink.ts:18778](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18778)
+Defined in: [neurolink.ts:18784](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18784)
 
 Get the current authentication context.
 
@@ -4817,7 +4817,7 @@ Checks AsyncLocalStorage first, then falls back to the global holder.
 
 > **clearAuthContext**(): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:18786](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18786)
+Defined in: [neurolink.ts:18792](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18792)
 
 Clear the current authentication context
 
@@ -4831,7 +4831,7 @@ Clear the current authentication context
 
 > **getExternalServerManager**(): [`ExternalServerManager`](ExternalServerManager.md)
 
-Defined in: [neurolink.ts:18800](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18800)
+Defined in: [neurolink.ts:18806](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18806)
 
 Get the external server manager instance
 Used internally by server adapters for external MCP server management

--- a/docs/api/type-aliases/EnhancedGenerateResult.md
+++ b/docs/api/type-aliases/EnhancedGenerateResult.md
@@ -8,7 +8,7 @@
 
 > **EnhancedGenerateResult** = [`GenerateResult`](GenerateResult.md) & `object`
 
-Defined in: [types/generate.ts:1728](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1728)
+Defined in: [types/generate.ts:1734](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1734)
 
 ## Type Declaration
 

--- a/docs/api/type-aliases/GenerateOptionsNormalized.md
+++ b/docs/api/type-aliases/GenerateOptionsNormalized.md
@@ -8,7 +8,7 @@
 
 > **GenerateOptionsNormalized** = [`GenerateOptions`](GenerateOptions.md) & `object`
 
-Defined in: [types/generate.ts:1755](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1755)
+Defined in: [types/generate.ts:1761](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1761)
 
 Internal alias used by messageBuilder helpers after the entry-point
 (`buildMultimodalMessagesArray`) has guaranteed that `input` is non-null.

--- a/docs/api/type-aliases/GenerationCallConfig.md
+++ b/docs/api/type-aliases/GenerationCallConfig.md
@@ -8,7 +8,7 @@
 
 > **GenerationCallConfig** = `object`
 
-Defined in: [types/generate.ts:1763](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1763)
+Defined in: [types/generate.ts:1769](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1769)
 
 Per-call configuration for GenerationHandler's AI-SDK loop invocation,
 shared by the initial call and every fallback retry so they cannot drift.
@@ -19,7 +19,7 @@ shared by the initial call and every fallback retry so they cannot drift.
 
 > **shouldUseTools**: `boolean`
 
-Defined in: [types/generate.ts:1764](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1764)
+Defined in: [types/generate.ts:1770](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1770)
 
 ---
 
@@ -27,7 +27,7 @@ Defined in: [types/generate.ts:1764](https://github.com/juspay/neurolink/blob/re
 
 > **includeStructuredOutput**: `boolean`
 
-Defined in: [types/generate.ts:1765](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1765)
+Defined in: [types/generate.ts:1771](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1771)
 
 ---
 
@@ -35,7 +35,7 @@ Defined in: [types/generate.ts:1765](https://github.com/juspay/neurolink/blob/re
 
 > **turnStartMs**: `number`
 
-Defined in: [types/generate.ts:1769](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1769)
+Defined in: [types/generate.ts:1775](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1775)
 
 Anchor for the turn deadline — the ORIGINAL executeGeneration start,
 shared across fallback/provider retries so they can't refresh the
@@ -47,7 +47,7 @@ wall-clock budget.
 
 > `optional` **promptJsonInstruction?**: `boolean`
 
-Defined in: [types/generate.ts:1772](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1772)
+Defined in: [types/generate.ts:1778](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1778)
 
 Structured-output fallback retry: also spell the JSON Schema out in the
 system prompt, for vendors that ignore `response_format`.
@@ -58,6 +58,6 @@ system prompt, for vendors that ignore `response_format`.
 
 > `optional` **isToolReask?**: `boolean`
 
-Defined in: [types/generate.ts:1774](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1774)
+Defined in: [types/generate.ts:1780](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1780)
 
 Set on the single toolChoice:"none" re-ask so it can never recurse.

--- a/docs/api/type-aliases/ModelAliasConfig.md
+++ b/docs/api/type-aliases/ModelAliasConfig.md
@@ -8,7 +8,7 @@
 
 > **ModelAliasConfig** = `object`
 
-Defined in: [types/generate.ts:1738](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1738)
+Defined in: [types/generate.ts:1744](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1744)
 
 NL-004: Model alias/deprecation configuration.
 Allows mapping deprecated model names to their replacements.
@@ -19,4 +19,4 @@ Allows mapping deprecated model names to their replacements.
 
 > **aliases**: `Record`\<`string`, \{ `target`: `string`; `action`: `"warn"` \| `"redirect"` \| `"block"`; `reason?`: `string`; \}\>
 
-Defined in: [types/generate.ts:1739](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1739)
+Defined in: [types/generate.ts:1745](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1745)

--- a/docs/api/type-aliases/NativeGenerateLoopArgs.md
+++ b/docs/api/type-aliases/NativeGenerateLoopArgs.md
@@ -8,7 +8,7 @@
 
 > **NativeGenerateLoopArgs** = `object`
 
-Defined in: [types/generate.ts:1782](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1782)
+Defined in: [types/generate.ts:1788](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1788)
 
 Inputs to the shared native generate loop (`core/nativeGenerateLoop.ts`).
 One loop serves every provider whose delegating model exposes a v3-shaped
@@ -20,7 +20,7 @@ One loop serves every provider whose delegating model exposes a v3-shaped
 
 > **doGenerate**: (`options`) => `Promise`\<`Record`\<`string`, `unknown`\>\>
 
-Defined in: [types/generate.ts:1783](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1783)
+Defined in: [types/generate.ts:1789](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1789)
 
 #### Parameters
 
@@ -38,7 +38,7 @@ Defined in: [types/generate.ts:1783](https://github.com/juspay/neurolink/blob/re
 
 > **conversation**: `Record`\<`string`, `unknown`\>[]
 
-Defined in: [types/generate.ts:1787](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1787)
+Defined in: [types/generate.ts:1793](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1793)
 
 Conversation in the message-builder shape each doGenerate converts itself.
 
@@ -48,7 +48,7 @@ Conversation in the message-builder shape each doGenerate converts itself.
 
 > `optional` **tools?**: `Record`\<`string`, `unknown`\>[]
 
-Defined in: [types/generate.ts:1789](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1789)
+Defined in: [types/generate.ts:1795](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1795)
 
 Tool declarations in the v3 shape doGenerate already knows how to convert.
 
@@ -58,7 +58,7 @@ Tool declarations in the v3 shape doGenerate already knows how to convert.
 
 > **toolsRecord**: `Record`\<`string`, `unknown`\>
 
-Defined in: [types/generate.ts:1791](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1791)
+Defined in: [types/generate.ts:1797](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1797)
 
 Registered tools, used to execute a call the model asks for.
 
@@ -68,7 +68,7 @@ Registered tools, used to execute a call the model asks for.
 
 > `optional` **toolChoice?**: `unknown`
 
-Defined in: [types/generate.ts:1792](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1792)
+Defined in: [types/generate.ts:1798](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1798)
 
 ---
 
@@ -76,7 +76,7 @@ Defined in: [types/generate.ts:1792](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **responseFormat?**: `Record`\<`string`, `unknown`\>
 
-Defined in: [types/generate.ts:1793](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1793)
+Defined in: [types/generate.ts:1799](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1799)
 
 ---
 
@@ -84,7 +84,7 @@ Defined in: [types/generate.ts:1793](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **providerOptions?**: `Record`\<`string`, `Record`\<`string`, `unknown`\>\>
 
-Defined in: [types/generate.ts:1794](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1794)
+Defined in: [types/generate.ts:1800](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1800)
 
 ---
 
@@ -92,7 +92,7 @@ Defined in: [types/generate.ts:1794](https://github.com/juspay/neurolink/blob/re
 
 > **maxSteps**: `number`
 
-Defined in: [types/generate.ts:1795](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1795)
+Defined in: [types/generate.ts:1801](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1801)
 
 ---
 
@@ -100,7 +100,7 @@ Defined in: [types/generate.ts:1795](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **maxOutputTokens?**: `number`
 
-Defined in: [types/generate.ts:1796](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1796)
+Defined in: [types/generate.ts:1802](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1802)
 
 ---
 
@@ -108,7 +108,7 @@ Defined in: [types/generate.ts:1796](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **temperature?**: `number`
 
-Defined in: [types/generate.ts:1797](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1797)
+Defined in: [types/generate.ts:1803](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1803)
 
 ---
 
@@ -116,7 +116,7 @@ Defined in: [types/generate.ts:1797](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **abortSignal?**: `AbortSignal`
 
-Defined in: [types/generate.ts:1798](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1798)
+Defined in: [types/generate.ts:1804](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1804)
 
 ---
 
@@ -124,7 +124,7 @@ Defined in: [types/generate.ts:1798](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **toolTimeoutMs?**: `number`
 
-Defined in: [types/generate.ts:1800](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1800)
+Defined in: [types/generate.ts:1806](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1806)
 
 Per-tool-execution cap, forwarded into `guardToolExecutor`.
 
@@ -134,7 +134,7 @@ Per-tool-execution cap, forwarded into `guardToolExecutor`.
 
 > **runStep**: (`call`) => `Promise`\<`Record`\<`string`, `unknown`\>\>
 
-Defined in: [types/generate.ts:1802](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1802)
+Defined in: [types/generate.ts:1808](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1808)
 
 Wraps one step: retry ladder plus provider error classification.
 

--- a/docs/api/type-aliases/NativeGenerateLoopResult.md
+++ b/docs/api/type-aliases/NativeGenerateLoopResult.md
@@ -8,7 +8,7 @@
 
 > **NativeGenerateLoopResult** = `object`
 
-Defined in: [types/generate.ts:1807](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1807)
+Defined in: [types/generate.ts:1813](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1813)
 
 ## Properties
 
@@ -16,7 +16,7 @@ Defined in: [types/generate.ts:1807](https://github.com/juspay/neurolink/blob/re
 
 > **text**: `string`
 
-Defined in: [types/generate.ts:1808](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1808)
+Defined in: [types/generate.ts:1814](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1814)
 
 ---
 
@@ -24,7 +24,7 @@ Defined in: [types/generate.ts:1808](https://github.com/juspay/neurolink/blob/re
 
 > **finishReason**: `string`
 
-Defined in: [types/generate.ts:1809](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1809)
+Defined in: [types/generate.ts:1815](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1815)
 
 ---
 
@@ -32,7 +32,7 @@ Defined in: [types/generate.ts:1809](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **rawFinishReason?**: `string`
 
-Defined in: [types/generate.ts:1810](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1810)
+Defined in: [types/generate.ts:1816](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1816)
 
 ---
 
@@ -40,7 +40,7 @@ Defined in: [types/generate.ts:1810](https://github.com/juspay/neurolink/blob/re
 
 > **inputTokens**: `number`
 
-Defined in: [types/generate.ts:1811](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1811)
+Defined in: [types/generate.ts:1817](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1817)
 
 ---
 
@@ -48,7 +48,7 @@ Defined in: [types/generate.ts:1811](https://github.com/juspay/neurolink/blob/re
 
 > **outputTokens**: `number`
 
-Defined in: [types/generate.ts:1812](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1812)
+Defined in: [types/generate.ts:1818](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1818)
 
 ---
 
@@ -56,7 +56,7 @@ Defined in: [types/generate.ts:1812](https://github.com/juspay/neurolink/blob/re
 
 > **cacheReadTokens**: `number`
 
-Defined in: [types/generate.ts:1813](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1813)
+Defined in: [types/generate.ts:1819](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1819)
 
 ---
 
@@ -64,7 +64,7 @@ Defined in: [types/generate.ts:1813](https://github.com/juspay/neurolink/blob/re
 
 > **cacheWriteTokens**: `number`
 
-Defined in: [types/generate.ts:1814](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1814)
+Defined in: [types/generate.ts:1820](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1820)
 
 ---
 
@@ -72,7 +72,7 @@ Defined in: [types/generate.ts:1814](https://github.com/juspay/neurolink/blob/re
 
 > **toolsUsed**: `string`[]
 
-Defined in: [types/generate.ts:1815](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1815)
+Defined in: [types/generate.ts:1821](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1821)
 
 ---
 
@@ -80,4 +80,4 @@ Defined in: [types/generate.ts:1815](https://github.com/juspay/neurolink/blob/re
 
 > **steps**: `number`
 
-Defined in: [types/generate.ts:1816](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1816)
+Defined in: [types/generate.ts:1822](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1822)

--- a/docs/api/type-aliases/SingleShotRequest.md
+++ b/docs/api/type-aliases/SingleShotRequest.md
@@ -8,7 +8,7 @@
 
 > **SingleShotRequest** = `object`
 
-Defined in: [types/generate.ts:1819](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1819)
+Defined in: [types/generate.ts:1825](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1825)
 
 ## Properties
 
@@ -16,7 +16,7 @@ Defined in: [types/generate.ts:1819](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **system?**: `string`
 
-Defined in: [types/generate.ts:1820](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1820)
+Defined in: [types/generate.ts:1826](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1826)
 
 ---
 
@@ -24,7 +24,7 @@ Defined in: [types/generate.ts:1820](https://github.com/juspay/neurolink/blob/re
 
 > **prompt**: `string`
 
-Defined in: [types/generate.ts:1821](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1821)
+Defined in: [types/generate.ts:1827](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1827)
 
 ---
 
@@ -32,7 +32,7 @@ Defined in: [types/generate.ts:1821](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **maxOutputTokens?**: `number`
 
-Defined in: [types/generate.ts:1822](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1822)
+Defined in: [types/generate.ts:1828](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1828)
 
 ---
 
@@ -40,7 +40,7 @@ Defined in: [types/generate.ts:1822](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **temperature?**: `number`
 
-Defined in: [types/generate.ts:1823](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1823)
+Defined in: [types/generate.ts:1829](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1829)
 
 ---
 
@@ -48,4 +48,4 @@ Defined in: [types/generate.ts:1823](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **abortSignal?**: `AbortSignal`
 
-Defined in: [types/generate.ts:1824](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1824)
+Defined in: [types/generate.ts:1830](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1830)

--- a/docs/api/type-aliases/SingleShotResult.md
+++ b/docs/api/type-aliases/SingleShotResult.md
@@ -8,7 +8,7 @@
 
 > **SingleShotResult** = `object`
 
-Defined in: [types/generate.ts:1827](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1827)
+Defined in: [types/generate.ts:1833](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1833)
 
 ## Properties
 
@@ -16,7 +16,7 @@ Defined in: [types/generate.ts:1827](https://github.com/juspay/neurolink/blob/re
 
 > **text**: `string`
 
-Defined in: [types/generate.ts:1828](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1828)
+Defined in: [types/generate.ts:1834](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1834)
 
 ---
 
@@ -24,7 +24,7 @@ Defined in: [types/generate.ts:1828](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **usage?**: `object`
 
-Defined in: [types/generate.ts:1829](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1829)
+Defined in: [types/generate.ts:1835](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1835)
 
 #### inputTokens?
 
@@ -44,4 +44,4 @@ Defined in: [types/generate.ts:1829](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **finishReason?**: `string`
 
-Defined in: [types/generate.ts:1830](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1830)
+Defined in: [types/generate.ts:1836](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1836)

--- a/docs/api/type-aliases/TTSMetadata.md
+++ b/docs/api/type-aliases/TTSMetadata.md
@@ -8,7 +8,7 @@
 
 > **TTSMetadata** = `object`
 
-Defined in: [types/generate.ts:1713](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1713)
+Defined in: [types/generate.ts:1719](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1719)
 
 Enhanced result type with optional analytics/evaluation
 
@@ -18,7 +18,7 @@ Enhanced result type with optional analytics/evaluation
 
 > **attempted**: `boolean`
 
-Defined in: [types/generate.ts:1715](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1715)
+Defined in: [types/generate.ts:1721](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1721)
 
 Whether TTS synthesis was invoked. False indicates TTS was skipped.
 
@@ -28,7 +28,7 @@ Whether TTS synthesis was invoked. False indicates TTS was skipped.
 
 > **success**: `boolean`
 
-Defined in: [types/generate.ts:1717](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1717)
+Defined in: [types/generate.ts:1723](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1723)
 
 Whether TTS synthesis completed successfully.
 
@@ -38,7 +38,7 @@ Whether TTS synthesis completed successfully.
 
 > `optional` **error?**: `object`
 
-Defined in: [types/generate.ts:1719](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1719)
+Defined in: [types/generate.ts:1725](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1725)
 
 Structured synthesis error details, present only when synthesis failed.
 
@@ -60,6 +60,6 @@ Structured synthesis error details, present only when synthesis failed.
 
 > `optional` **latency?**: `number`
 
-Defined in: [types/generate.ts:1725](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1725)
+Defined in: [types/generate.ts:1731](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1731)
 
 TTS synthesis time in milliseconds.

--- a/docs/api/type-aliases/TextGenerationResult.md
+++ b/docs/api/type-aliases/TextGenerationResult.md
@@ -74,6 +74,12 @@ True when the schema JSON appears truncated (output hit the token cap).
 
 > `optional` **responseTime?**: `number`
 
+### toolCalls?
+
+> `optional` **toolCalls?**: `object`[]
+
+The executed tool calls of a native turn — the same shape `GenerateResult` exposes.
+
 ### toolsUsed?
 
 > `optional` **toolsUsed?**: `string`[]

--- a/src/lib/core/toolExecutionRecorder.ts
+++ b/src/lib/core/toolExecutionRecorder.ts
@@ -14,6 +14,8 @@ import type {
   Tool,
   ToolExecutionCaptureOptions,
   ToolExecutionRecord,
+  StandardRecord,
+  ToolExecutionSummaryInternal,
 } from "../types/index.js";
 import { logger } from "../utils/logger.js";
 
@@ -302,6 +304,31 @@ export function toToolExecutionRecords(
  * carried a recorder that saw executions, else a conversion of the loop's
  * legacy accumulator entries.
  */
+/**
+ * The public `toolCalls` view of a native turn's execution summaries.
+ *
+ * The native generate loops record every executed call in
+ * `ToolExecutionSummaryInternal[]` and surface it as `toolExecutions`, but
+ * never mapped it onto `EnhancedGenerateResult.toolCalls` — the field the type
+ * has always declared and the ai-package formatter used to fill. A caller
+ * reading `result.toolCalls` after a tool ran saw nothing. This is the one
+ * place that mapping lives, so the three native paths cannot drift apart.
+ */
+export function toolCallsFromSummaries(
+  summaries: ReadonlyArray<ToolExecutionSummaryInternal>,
+): Array<{ toolCallId: string; toolName: string; args: StandardRecord }> {
+  return summaries.map((summary) => ({
+    toolCallId: summary.toolCallId,
+    toolName: summary.toolName,
+    args:
+      summary.input !== null &&
+      typeof summary.input === "object" &&
+      !Array.isArray(summary.input)
+        ? (summary.input as StandardRecord)
+        : {},
+  }));
+}
+
 export function resolveToolExecutionRecords(
   options: unknown,
   legacyExecutions?: unknown[],

--- a/src/lib/neurolink.ts
+++ b/src/lib/neurolink.ts
@@ -5871,6 +5871,7 @@ Current user's request: ${currentInput}`;
         : undefined,
       responseTime: textResult.responseTime,
       toolsUsed: textResult.toolsUsed,
+      toolCalls: textResult.toolCalls ?? [],
       toolExecutions: toToolExecutionRecords(textResult.toolExecutions),
       enhancedWithTools: textResult.enhancedWithTools,
       availableTools: transformAvailableTools(textResult.availableTools),
@@ -8085,6 +8086,7 @@ Current user's request: ${currentInput}`;
       rawFinishReason: result.rawFinishReason,
       stepsUsed: result.stepsUsed,
       toolsUsed: result.toolsUsed || [],
+      toolCalls: result.toolCalls ?? [],
       toolExecutions: transformedToolExecutions,
       enhancedWithTools: Boolean(hasToolExecutions),
       availableTools: transformToolsForMCP(
@@ -8277,6 +8279,7 @@ Current user's request: ${currentInput}`;
             rawFinishReason: poolResult.rawFinishReason,
             stepsUsed: poolResult.stepsUsed,
             toolsUsed: poolResult.toolsUsed || [],
+            toolCalls: poolResult.toolCalls ?? [],
             // Lossless pass-through: keep the full ToolExecutionRecord
             // fields (params/resultText/isError/timing) alongside the
             // legacy {toolName,executionTime,success} shape this internal
@@ -8749,6 +8752,9 @@ Current user's request: ${currentInput}`;
           rawFinishReason: result.rawFinishReason,
           stepsUsed: result.stepsUsed,
           toolsUsed: result.toolsUsed || [],
+          // The providers record executed calls; without this line the public
+          // result never carried them, whatever the provider returned.
+          toolCalls: result.toolCalls ?? [],
           // Lossless pass-through: keep the full ToolExecutionRecord fields
           // alongside the legacy {toolName,executionTime,success} shape this
           // internal result declares, so the final GenerateResult mapping

--- a/src/lib/providers/amazonSagemaker.ts
+++ b/src/lib/providers/amazonSagemaker.ts
@@ -16,7 +16,10 @@ import type {
 } from "../types/index.js";
 import { logger } from "../utils/logger.js";
 import { resolveRequestKind } from "../core/resolveRequestKind.js";
-import { resolveToolExecutionRecords } from "../core/toolExecutionRecorder.js";
+import {
+  resolveToolExecutionRecords,
+  toolCallsFromSummaries,
+} from "../core/toolExecutionRecorder.js";
 import { transformToolExecutions } from "../utils/transformationUtils.js";
 import { convertZodToJsonSchema } from "../utils/schemaConversion.js";
 import { withProviderRetry } from "../utils/providerRetry.js";
@@ -282,6 +285,7 @@ export class AmazonSageMakerProvider extends BaseProvider {
       },
       responseTime: Date.now() - startTime,
       toolsUsed: loop.toolsUsed,
+      toolCalls: toolCallsFromSummaries(toolExecutionSummaries),
       toolExecutions: resolveToolExecutionRecords(
         options,
         transformToolExecutions(toolExecutionSummaries),

--- a/src/lib/providers/anthropic/client.ts
+++ b/src/lib/providers/anthropic/client.ts
@@ -95,7 +95,10 @@ import {
 } from "../../core/nativeGenerateLoop.js";
 import { withProviderRetry } from "../../utils/providerRetry.js";
 import { resolveRequestKind } from "../../core/resolveRequestKind.js";
-import { resolveToolExecutionRecords } from "../../core/toolExecutionRecorder.js";
+import {
+  resolveToolExecutionRecords,
+  toolCallsFromSummaries,
+} from "../../core/toolExecutionRecorder.js";
 import { transformToolExecutions } from "../../utils/transformationUtils.js";
 import {
   createAnthropicConfig,
@@ -1891,6 +1894,7 @@ export class AnthropicProvider extends BaseProvider {
       },
       responseTime: Date.now() - startTime,
       toolsUsed: loop.toolsUsed,
+      toolCalls: toolCallsFromSummaries(toolExecutionSummaries),
       toolExecutions: resolveToolExecutionRecords(
         options,
         transformToolExecutions(toolExecutionSummaries),

--- a/src/lib/providers/openaiChatCompletionsBase.ts
+++ b/src/lib/providers/openaiChatCompletionsBase.ts
@@ -87,7 +87,10 @@ import {
   hasNativeDoGenerate,
   runNativeGenerateLoop,
 } from "../core/nativeGenerateLoop.js";
-import { resolveToolExecutionRecords } from "../core/toolExecutionRecorder.js";
+import {
+  resolveToolExecutionRecords,
+  toolCallsFromSummaries,
+} from "../core/toolExecutionRecorder.js";
 import { convertZodToJsonSchema } from "../utils/schemaConversion.js";
 import { coerceJsonToSchema, schemaAccepts } from "../utils/json/coerce.js";
 import { resolveToolChoice } from "../utils/toolChoice.js";
@@ -1249,6 +1252,7 @@ export abstract class OpenAIChatCompletionsProvider extends BaseProvider {
       },
       responseTime: Date.now() - startTime,
       toolsUsed,
+      toolCalls: toolCallsFromSummaries(toolExecutionSummaries),
       toolExecutions: resolveToolExecutionRecords(
         options,
         transformToolExecutions(toolExecutionSummaries),

--- a/src/lib/types/generate.ts
+++ b/src/lib/types/generate.ts
@@ -1677,6 +1677,12 @@ export type TextGenerationResult = {
   model?: string;
   usage?: TokenUsage;
   responseTime?: number;
+  /** The executed tool calls of a native turn — the same shape `GenerateResult` exposes. */
+  toolCalls?: Array<{
+    toolCallId: string;
+    toolName: string;
+    args: StandardRecord;
+  }>;
   toolsUsed?: string[];
   toolExecutions?: Array<{
     toolName: string;

--- a/test/continuous-test-suite-native-vendor-recovery.ts
+++ b/test/continuous-test-suite-native-vendor-recovery.ts
@@ -232,4 +232,58 @@ await test("a silently ignored response_format falls back to the schema in the s
   }
 });
 
+await test("a native tool round trip populates result.toolCalls", async () => {
+  // `EnhancedGenerateResult.toolCalls` is a public field. The native loop
+  // recorded the execution (toolExecutions, toolsUsed) but never mapped it
+  // back onto toolCalls, so a caller reading the field the type promises saw
+  // nothing after a tool ran. Pre-dates the SDK removal for this family.
+  const server = await startScriptedChatServer([
+    chatCompletion({
+      finishReason: "tool_calls",
+      toolCalls: [
+        {
+          id: "call_7",
+          type: "function",
+          function: { name: "lookup", arguments: '{"value":7}' },
+        },
+      ],
+    }),
+    chatCompletion({ content: "answer 42", finishReason: "stop" }),
+  ]);
+  try {
+    const nl = new NeuroLink();
+    const result = await nl.generate({
+      input: { text: "call lookup" },
+      provider: "openai",
+      model: "scripted-model",
+      credentials: credentialsFor(server.baseURL),
+      maxSteps: 3,
+      tools: {
+        lookup: tool({
+          description: "Looks a value up",
+          inputSchema: z.object({ value: z.number() }),
+          execute: async () => ({ answer: 42 }),
+        }),
+      },
+    });
+    if (server.requestCount() < 2) {
+      throw new Error(
+        "precondition failed: the tool round trip never happened",
+      );
+    }
+    const calls = result.toolCalls ?? [];
+    if (calls.length !== 1) {
+      throw new Error("result.toolCalls does not carry the executed call");
+    }
+    if (calls[0].toolName !== "lookup" || calls[0].toolCallId !== "call_7") {
+      throw new Error("result.toolCalls carries the wrong identity");
+    }
+    if ((calls[0].args as { value?: number }).value !== 7) {
+      throw new Error("result.toolCalls carries the wrong arguments");
+    }
+  } finally {
+    await server.close();
+  }
+});
+
 await runSuite();


### PR DESCRIPTION
## What

After a native tool round trip, the public `generate()` result never carried `toolCalls` — a field `EnhancedGenerateResult` has always declared and that `test:mcp:cli` reads. A caller saw the tool run (`toolsUsed`, `toolExecutions` populated) and an empty `toolCalls`.

## Gap, not regression

A deterministic probe against a scripted server (tool call, then final message) shows `toolCalls` absent at **1375cbfcb** (before the SDK removal) exactly as at the release tip, with the tool executed once and `toolExecutions` populated both times. This predates the removal.

## Three layers dropped it, independently

1. **Providers.** The three native generate paths (OpenAI-compatible base, Anthropic, SageMaker) built their result from the loop's execution summaries and never mapped them onto `toolCalls`. Vertex and AI Studio did. `toolCallsFromSummaries` in `toolExecutionRecorder.ts` is now the one mapping, so the three cannot drift apart.
2. **`NeuroLink.generate()`** reassembles the public result field by field at four sites — `generateWithMCPProvider`, the direct-provider assembly, the model-pool assembly, and `finalizeGenerateRequestResult` (whose own comment warns that new provider fields "silently vanish" here) — and none copied `toolCalls`. All four now do, with `?? []`.
3. **`TextGenerationResult`** did not declare the field, so layer 2 failed typecheck. Without this the build was red while the suite still passed on tsc's emitted-anyway output — caught before commit.

## Proof (red first)

New case in `test:vendor-recovery`: a scripted server answers with a tool call then a final message; the case asserts `result.toolCalls` carries exactly the executed call with id, name and parsed args.

| build under test | result |
| --- | --- |
| unfixed | ✗ |
| layer 1 only | ✗ |
| layers 1 + two of four SDK sites | ✗ (a provider-layer probe showed the value leaving the provider intact — how the last two sites were found) |
| all layers | ✓ |

Gates on the final code: `check` 0, `build` 0, `lint` 0, `check:tools-tests` 0, `test:providers-mocked` **95/95**, `test:vendor-recovery` **4/4**. SDK-layer probe returns `toolCalls: [{ toolCallId: "call_1", toolName: "lookup", args: { value: 7 } }]`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Generated results now include tool-call details, including the tool name, call ID, and arguments.
  * Tool-call information is available consistently across standard, MCP, model pool, and supported native provider generations.
  * Legacy text generation results now expose tool-call data when available.

* **Bug Fixes**
  * Preserved tool-call information through native tool execution round trips.

* **Tests**
  * Added coverage verifying tool-call details are returned correctly after native tool execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->