### PR TITLE
test(suites): stop two live suites reporting defects that are the harness's own

### DIFF
--- a/test/continuous-test-suite-media-gen.ts
+++ b/test/continuous-test-suite-media-gen.ts
@@ -1511,10 +1511,9 @@ async function testVideoGenerationVertexAI(): Promise<boolean | null> {
 
 import { NeuroLink } from '${process.cwd()}/dist/index.js';
 
-import { assertDistFresh } from "./helpers/distFreshness.js";
-
-// Fail loudly rather than silently testing a stale build (see distFreshness.ts).
-assertDistFresh();
+// No freshness check here: this script runs from a temp directory with no
+// ./helpers to import it from, and the parent suite already ran
+// assertDistFresh() against the same dist before writing this file.
 
 async function testVideoGenerationVertexAI() {
   console.log('Testing video generation via Vertex AI generate()...');

--- a/test/continuous-test-suite-middleware.ts
+++ b/test/continuous-test-suite-middleware.ts
@@ -136,7 +136,7 @@ async function testGenerateOnFinish(): Promise<boolean | null> {
       model: TEST_CONFIG.model,
       thinkingLevel: TEST_CONFIG.thinkingLevel,
       disableTools: TEST_CONFIG.disableTools,
-      maxTokens: 50,
+      maxTokens: 200,
       onFinish: (payload) => {
         finishPayload = payload;
       },
@@ -271,7 +271,7 @@ async function testGenerateCallbackIsolation(): Promise<boolean | null> {
       model: TEST_CONFIG.model,
       thinkingLevel: TEST_CONFIG.thinkingLevel,
       disableTools: TEST_CONFIG.disableTools,
-      maxTokens: 50,
+      maxTokens: 200,
       onFinish: () => {
         throw new Error("Consumer callback blew up");
       },
@@ -333,7 +333,7 @@ async function testStreamOnFinish(): Promise<boolean | null> {
       model: TEST_CONFIG.model,
       thinkingLevel: TEST_CONFIG.thinkingLevel,
       disableTools: TEST_CONFIG.disableTools,
-      maxTokens: 50,
+      maxTokens: 200,
       onFinish: (payload) => {
         finishPayload = payload;
       },
@@ -541,7 +541,7 @@ async function testStreamCallbackIsolation(): Promise<boolean | null> {
       model: TEST_CONFIG.model,
       thinkingLevel: TEST_CONFIG.thinkingLevel,
       disableTools: TEST_CONFIG.disableTools,
-      maxTokens: 50,
+      maxTokens: 200,
       onFinish: () => {
         throw new Error("Consumer stream callback blew up");
       },

--- a/test/continuous-test-suite-provider-matrix-cli.ts
+++ b/test/continuous-test-suite-provider-matrix-cli.ts
@@ -140,7 +140,7 @@ async function runMatrix(): Promise<void> {
           "--model",
           p.defaultModel,
           "--maxTokens",
-          "30",
+          "200",
           "--disableTools",
           "Reply with the single word HELLO and nothing else.",
         ]);
@@ -165,7 +165,7 @@ async function runMatrix(): Promise<void> {
               "--model",
               p.defaultModel,
               "--maxTokens",
-              "30",
+              "200",
               "--disableTools",
               "Count from 1 to 3.",
             ]);

--- a/test/continuous-test-suite-provider-matrix.ts
+++ b/test/continuous-test-suite-provider-matrix.ts
@@ -94,7 +94,11 @@ async function runMatrix(): Promise<void> {
             const r = await sdk.generate({
               ...baseOpts,
               input: { text: "Reply with exactly: HELLO" },
-              maxTokens: 50,
+              // Several catalog defaults are reasoning models (Cerebras and Groq
+              // gpt-oss-120b, Fireworks kimi) that spend the whole budget on
+              // hidden reasoning at 50 and return empty text with
+              // finishReason "length". 200 matches the other cells.
+              maxTokens: 200,
               disableTools: true,
             } as never);
             lastContent = r.content;
@@ -117,7 +121,7 @@ async function runMatrix(): Promise<void> {
             const r = await sdk.stream({
               ...baseOpts,
               input: { text: "Count from 1 to 3." },
-              maxTokens: 50,
+              maxTokens: 200,
               disableTools: true,
             } as never);
             let count = 0;


### PR DESCRIPTION
## What

Three live suites reported harness defects as provider failures, found during the full post-removal re-test.

**Reasoning budgets.** The SDK and CLI provider matrices gave every model a 50-token budget (30 on the CLI matrix), and the lifecycle-middleware suite did the same against Vertex. Cerebras' and Groq's default is `gpt-oss-120b`, Fireworks' is `kimi-k2p6`, Vertex's is `gemini-2.5-flash` — all reasoning models. At 50 tokens Cerebras returned zero characters with `finishReason: "length"` and 50 output tokens: the whole budget went to hidden reasoning. Groq and Fireworks did the same intermittently, and a probe with the lifecycle suite's own prompt shows Vertex spending **28 of 29** output tokens on reasoning at 50 — one token from an empty reply. Every one of those cells reported "empty response". The SDK was reporting the truncation correctly the whole time. All three suites now use 200, which the other matrix cells already did.

**Media suite crash.** The Vertex video case writes a script into a temp directory and that script imported `./helpers/distFreshness.js` relative to the temp directory, where no `helpers/` exists. It crashed with `ERR_MODULE_NOT_FOUND` before any API call, every run. The parent suite already runs `assertDistFresh()` against the same dist before writing the file, so the child's copy was redundant and is removed.

## Verified live at the new budget

| suite | result |
| --- | --- |
| `test:matrix --provider=cerebras,groq,fireworks` | 15/15 (generate and stream) |
| `test:matrix:cli --provider=cerebras,groq,fireworks` | 6/6 |
| `test:middleware` (Vertex) | 7/7 |
| `check:test-parse`, `check:tools-tests`, `build` | clean |

No source change; four test files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated video generation test setup to rely on freshness validation performed by the parent suite.
  - Increased token limits in middleware and provider matrix tests to support reasoning-model responses and prevent premature length-based completion.
  - Added clarification explaining the higher token budget required for certain model responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->