### PR TITLE
fix(middleware): filter guardrail text runs whole, not per part or per delta

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -458,6 +458,7 @@ console.log(result.content);
 - [LanguageModelV3ToolCall](type-aliases/LanguageModelV3ToolCall.md)
 - [LanguageModelV3Source](type-aliases/LanguageModelV3Source.md)
 - [LanguageModelV3ToolChoice](type-aliases/LanguageModelV3ToolChoice.md)
+- [LanguageModelV3Content](type-aliases/LanguageModelV3Content.md)
 - [LanguageModelV3GenerateResult](type-aliases/LanguageModelV3GenerateResult.md)
 - [LanguageModelV3StreamPart](type-aliases/LanguageModelV3StreamPart.md)
 - [LanguageModelV3StreamResult](type-aliases/LanguageModelV3StreamResult.md)

--- a/docs/api/type-aliases/AbortSignalMiddlewareOptions.md
+++ b/docs/api/type-aliases/AbortSignalMiddlewareOptions.md
@@ -8,7 +8,7 @@
 
 > **AbortSignalMiddlewareOptions** = `object`
 
-Defined in: [types/middleware.ts:396](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L396)
+Defined in: [types/middleware.ts:397](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L397)
 
 Options for the abort-signal middleware.
 
@@ -18,7 +18,7 @@ Options for the abort-signal middleware.
 
 > `optional` **onAbort?**: (`ctx`) => `void`
 
-Defined in: [types/middleware.ts:397](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L397)
+Defined in: [types/middleware.ts:398](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L398)
 
 #### Parameters
 
@@ -36,4 +36,4 @@ Defined in: [types/middleware.ts:397](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **timeout?**: `number`
 
-Defined in: [types/middleware.ts:398](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L398)
+Defined in: [types/middleware.ts:399](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L399)

--- a/docs/api/type-aliases/ApiKeyAuthOptions.md
+++ b/docs/api/type-aliases/ApiKeyAuthOptions.md
@@ -8,7 +8,7 @@
 
 > **ApiKeyAuthOptions** = `object`
 
-Defined in: [types/middleware.ts:414](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L414)
+Defined in: [types/middleware.ts:415](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L415)
 
 Options for the API-key auth middleware.
 
@@ -18,7 +18,7 @@ Options for the API-key auth middleware.
 
 > `optional` **headerName?**: `string`
 
-Defined in: [types/middleware.ts:415](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L415)
+Defined in: [types/middleware.ts:416](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L416)
 
 ---
 
@@ -26,4 +26,4 @@ Defined in: [types/middleware.ts:415](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **skipPaths?**: `string`[]
 
-Defined in: [types/middleware.ts:416](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L416)
+Defined in: [types/middleware.ts:417](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L417)

--- a/docs/api/type-aliases/AutoEvaluationConfig.md
+++ b/docs/api/type-aliases/AutoEvaluationConfig.md
@@ -8,7 +8,7 @@
 
 > **AutoEvaluationConfig** = `object`
 
-Defined in: [types/middleware.ts:200](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L200)
+Defined in: [types/middleware.ts:201](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L201)
 
 Configuration for the Auto-Evaluation Middleware.
 
@@ -18,7 +18,7 @@ Configuration for the Auto-Evaluation Middleware.
 
 > `optional` **threshold?**: `number`
 
-Defined in: [types/middleware.ts:202](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L202)
+Defined in: [types/middleware.ts:203](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L203)
 
 The minimum score (1-10) for a response to be considered passing.
 
@@ -28,7 +28,7 @@ The minimum score (1-10) for a response to be considered passing.
 
 > `optional` **maxRetries?**: `number`
 
-Defined in: [types/middleware.ts:204](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L204)
+Defined in: [types/middleware.ts:205](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L205)
 
 The maximum number of retry attempts before failing.
 
@@ -38,7 +38,7 @@ The maximum number of retry attempts before failing.
 
 > `optional` **evaluationModel?**: `string`
 
-Defined in: [types/middleware.ts:206](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L206)
+Defined in: [types/middleware.ts:207](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L207)
 
 The model to use for the LLM-as-judge evaluation.
 
@@ -48,7 +48,7 @@ The model to use for the LLM-as-judge evaluation.
 
 > `optional` **blocking?**: `boolean`
 
-Defined in: [types/middleware.ts:211](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L211)
+Defined in: [types/middleware.ts:212](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L212)
 
 If true, the middleware will wait for the evaluation to complete before returning.
 If the evaluation fails, it will throw an error. Defaults to true.
@@ -59,7 +59,7 @@ If the evaluation fails, it will throw an error. Defaults to true.
 
 > `optional` **onEvaluationComplete?**: (`evaluation`) => `void` \| `Promise`\<`void`\>
 
-Defined in: [types/middleware.ts:213](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L213)
+Defined in: [types/middleware.ts:214](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L214)
 
 A callback function to be invoked with the evaluation result.
 
@@ -79,7 +79,7 @@ A callback function to be invoked with the evaluation result.
 
 > `optional` **offTopicThreshold?**: `number`
 
-Defined in: [types/middleware.ts:215](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L215)
+Defined in: [types/middleware.ts:216](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L216)
 
 The score below which a response is considered off-topic.
 
@@ -89,7 +89,7 @@ The score below which a response is considered off-topic.
 
 > `optional` **highSeverityThreshold?**: `number`
 
-Defined in: [types/middleware.ts:217](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L217)
+Defined in: [types/middleware.ts:218](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L218)
 
 The score below which a failing response is considered a high severity alert.
 
@@ -99,7 +99,7 @@ The score below which a failing response is considered a high severity alert.
 
 > `optional` **promptGenerator?**: [`GetPromptFunction`](GetPromptFunction.md)
 
-Defined in: [types/middleware.ts:219](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L219)
+Defined in: [types/middleware.ts:220](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L220)
 
 ---
 
@@ -107,4 +107,4 @@ Defined in: [types/middleware.ts:219](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **provider?**: `string`
 
-Defined in: [types/middleware.ts:221](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L221)
+Defined in: [types/middleware.ts:222](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L222)

--- a/docs/api/type-aliases/BearerAuthOptions.md
+++ b/docs/api/type-aliases/BearerAuthOptions.md
@@ -8,7 +8,7 @@
 
 > **BearerAuthOptions** = `object`
 
-Defined in: [types/middleware.ts:402](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L402)
+Defined in: [types/middleware.ts:403](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L403)
 
 Options for the bearer-token auth middleware.
 
@@ -18,7 +18,7 @@ Options for the bearer-token auth middleware.
 
 > `optional` **required?**: `boolean`
 
-Defined in: [types/middleware.ts:403](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L403)
+Defined in: [types/middleware.ts:404](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L404)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/middleware.ts:403](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **headerName?**: `string`
 
-Defined in: [types/middleware.ts:404](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L404)
+Defined in: [types/middleware.ts:405](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L405)
 
 ---
 
@@ -34,4 +34,4 @@ Defined in: [types/middleware.ts:404](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **skipPaths?**: `string`[]
 
-Defined in: [types/middleware.ts:405](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L405)
+Defined in: [types/middleware.ts:406](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L406)

--- a/docs/api/type-aliases/BuiltInMiddlewareType.md
+++ b/docs/api/type-aliases/BuiltInMiddlewareType.md
@@ -8,6 +8,6 @@
 
 > **BuiltInMiddlewareType** = `"analytics"` \| `"guardrails"` \| `"logging"` \| `"caching"` \| `"rateLimit"` \| `"retry"` \| `"timeout"` \| `"autoEvaluation"` \| `"lifecycle"`
 
-Defined in: [types/middleware.ts:149](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L149)
+Defined in: [types/middleware.ts:150](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L150)
 
 Built-in middleware types

--- a/docs/api/type-aliases/DeprecationConfig.md
+++ b/docs/api/type-aliases/DeprecationConfig.md
@@ -8,7 +8,7 @@
 
 > **DeprecationConfig** = `object`
 
-Defined in: [types/middleware.ts:420](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L420)
+Defined in: [types/middleware.ts:421](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L421)
 
 Configuration for the route-deprecation middleware.
 
@@ -18,7 +18,7 @@ Configuration for the route-deprecation middleware.
 
 > **routes**: [`RouteDefinition`](RouteDefinition.md)[]
 
-Defined in: [types/middleware.ts:421](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L421)
+Defined in: [types/middleware.ts:422](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L422)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/middleware.ts:421](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **noticeHeader?**: `string`
 
-Defined in: [types/middleware.ts:422](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L422)
+Defined in: [types/middleware.ts:423](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L423)
 
 ---
 
@@ -34,4 +34,4 @@ Defined in: [types/middleware.ts:422](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **includeLink?**: `boolean`
 
-Defined in: [types/middleware.ts:423](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L423)
+Defined in: [types/middleware.ts:424](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L424)

--- a/docs/api/type-aliases/ExtendedPropertySchema.md
+++ b/docs/api/type-aliases/ExtendedPropertySchema.md
@@ -8,7 +8,7 @@
 
 > **ExtendedPropertySchema** = [`PropertySchema`](PropertySchema.md) & `object`
 
-Defined in: [types/middleware.ts:515](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L515)
+Defined in: [types/middleware.ts:516](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L516)
 
 PropertySchema with an extra `format` tag for common schemas.
 

--- a/docs/api/type-aliases/ExtendedValidationSchema.md
+++ b/docs/api/type-aliases/ExtendedValidationSchema.md
@@ -8,7 +8,7 @@
 
 > **ExtendedValidationSchema** = `object`
 
-Defined in: [types/middleware.ts:520](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L520)
+Defined in: [types/middleware.ts:521](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L521)
 
 Extended validation schema for common schemas.
 
@@ -18,7 +18,7 @@ Extended validation schema for common schemas.
 
 > `optional` **type?**: `string`
 
-Defined in: [types/middleware.ts:521](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L521)
+Defined in: [types/middleware.ts:522](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L522)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/middleware.ts:521](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **format?**: `string`
 
-Defined in: [types/middleware.ts:522](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L522)
+Defined in: [types/middleware.ts:523](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L523)
 
 ---
 
@@ -34,7 +34,7 @@ Defined in: [types/middleware.ts:522](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **required?**: `string`[]
 
-Defined in: [types/middleware.ts:523](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L523)
+Defined in: [types/middleware.ts:524](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L524)
 
 ---
 
@@ -42,7 +42,7 @@ Defined in: [types/middleware.ts:523](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **properties?**: `Record`\<`string`, [`ExtendedPropertySchema`](ExtendedPropertySchema.md)\>
 
-Defined in: [types/middleware.ts:524](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L524)
+Defined in: [types/middleware.ts:525](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L525)
 
 ---
 
@@ -50,4 +50,4 @@ Defined in: [types/middleware.ts:524](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **additionalProperties?**: `boolean`
 
-Defined in: [types/middleware.ts:525](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L525)
+Defined in: [types/middleware.ts:526](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L526)

--- a/docs/api/type-aliases/FixedWindowRateLimitConfig.md
+++ b/docs/api/type-aliases/FixedWindowRateLimitConfig.md
@@ -8,7 +8,7 @@
 
 > **FixedWindowRateLimitConfig** = `object`
 
-Defined in: [types/middleware.ts:452](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L452)
+Defined in: [types/middleware.ts:453](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L453)
 
 Simple fixed-window rate-limit configuration.
 
@@ -18,7 +18,7 @@ Simple fixed-window rate-limit configuration.
 
 > **maxRequests**: `number`
 
-Defined in: [types/middleware.ts:453](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L453)
+Defined in: [types/middleware.ts:454](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L454)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/middleware.ts:453](https://github.com/juspay/neurolink/blob/r
 
 > **windowMs**: `number`
 
-Defined in: [types/middleware.ts:454](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L454)
+Defined in: [types/middleware.ts:455](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L455)
 
 ---
 
@@ -34,7 +34,7 @@ Defined in: [types/middleware.ts:454](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **message?**: `string`
 
-Defined in: [types/middleware.ts:455](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L455)
+Defined in: [types/middleware.ts:456](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L456)
 
 ---
 
@@ -42,7 +42,7 @@ Defined in: [types/middleware.ts:455](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **skipPaths?**: `string`[]
 
-Defined in: [types/middleware.ts:456](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L456)
+Defined in: [types/middleware.ts:457](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L457)
 
 ---
 
@@ -50,7 +50,7 @@ Defined in: [types/middleware.ts:456](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **keyGenerator?**: (`ctx`) => `string`
 
-Defined in: [types/middleware.ts:457](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L457)
+Defined in: [types/middleware.ts:458](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L458)
 
 #### Parameters
 
@@ -68,7 +68,7 @@ Defined in: [types/middleware.ts:457](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **onRateLimitExceeded?**: (`ctx`, `retryAfter`) => `unknown`
 
-Defined in: [types/middleware.ts:458](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L458)
+Defined in: [types/middleware.ts:459](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L459)
 
 #### Parameters
 

--- a/docs/api/type-aliases/LanguageModelV3Content.md
+++ b/docs/api/type-aliases/LanguageModelV3Content.md
@@ -1,0 +1,11 @@
+[**NeuroLink API Reference**](../README.md)
+
+---
+
+[NeuroLink API Reference](../README.md) / LanguageModelV3Content
+
+# Type Alias: LanguageModelV3Content
+
+> **LanguageModelV3Content** = \{ `type`: `"text"`; `text`: `string`; \} \| \{ `type`: `"reasoning"`; `text`: `string`; \} \| \{ `type`: `"file"`; `data`: `unknown`; `mediaType`: `string`; \} \| [`LanguageModelV3ToolCall`](LanguageModelV3ToolCall.md) \| [`LanguageModelV3Source`](LanguageModelV3Source.md) \| `object` & `Record`\<`string`, `unknown`\> \| `object` & `Record`\<`string`, `unknown`\>
+
+Defined in: [types/aiCompat.ts:401](https://github.com/juspay/neurolink/blob/release/src/lib/types/aiCompat.ts#L401)

--- a/docs/api/type-aliases/LanguageModelV3GenerateResult.md
+++ b/docs/api/type-aliases/LanguageModelV3GenerateResult.md
@@ -14,7 +14,7 @@ Defined in: [types/aiCompat.ts:430](https://github.com/juspay/neurolink/blob/rel
 
 ### content
 
-> **content**: `LanguageModelV3Content`[]
+> **content**: [`LanguageModelV3Content`](LanguageModelV3Content.md)[]
 
 Defined in: [types/aiCompat.ts:431](https://github.com/juspay/neurolink/blob/release/src/lib/types/aiCompat.ts#L431)
 

--- a/docs/api/type-aliases/LifecycleChunkPayload.md
+++ b/docs/api/type-aliases/LifecycleChunkPayload.md
@@ -8,7 +8,7 @@
 
 > **LifecycleChunkPayload** = `object`
 
-Defined in: [types/middleware.ts:329](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L329)
+Defined in: [types/middleware.ts:330](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L330)
 
 Payload delivered to onChunk callbacks for each streaming chunk.
 
@@ -18,7 +18,7 @@ Payload delivered to onChunk callbacks for each streaming chunk.
 
 > **type**: `string`
 
-Defined in: [types/middleware.ts:331](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L331)
+Defined in: [types/middleware.ts:332](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L332)
 
 Chunk type from the AI SDK stream
 
@@ -28,7 +28,7 @@ Chunk type from the AI SDK stream
 
 > `optional` **textDelta?**: `string`
 
-Defined in: [types/middleware.ts:333](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L333)
+Defined in: [types/middleware.ts:334](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L334)
 
 Text content for text-delta chunks
 
@@ -38,6 +38,6 @@ Text content for text-delta chunks
 
 > **sequenceNumber**: `number`
 
-Defined in: [types/middleware.ts:335](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L335)
+Defined in: [types/middleware.ts:336](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L336)
 
 Zero-based chunk sequence number

--- a/docs/api/type-aliases/LifecycleErrorPayload.md
+++ b/docs/api/type-aliases/LifecycleErrorPayload.md
@@ -8,7 +8,7 @@
 
 > **LifecycleErrorPayload** = `object`
 
-Defined in: [types/middleware.ts:317](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L317)
+Defined in: [types/middleware.ts:318](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L318)
 
 Payload delivered to onError callbacks when generation or streaming fails.
 
@@ -18,7 +18,7 @@ Payload delivered to onError callbacks when generation or streaming fails.
 
 > **error**: `Error`
 
-Defined in: [types/middleware.ts:319](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L319)
+Defined in: [types/middleware.ts:320](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L320)
 
 The error that occurred
 
@@ -28,7 +28,7 @@ The error that occurred
 
 > **duration**: `number`
 
-Defined in: [types/middleware.ts:321](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L321)
+Defined in: [types/middleware.ts:322](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L322)
 
 Wall-clock duration until failure in milliseconds
 
@@ -38,6 +38,6 @@ Wall-clock duration until failure in milliseconds
 
 > **recoverable**: `boolean`
 
-Defined in: [types/middleware.ts:323](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L323)
+Defined in: [types/middleware.ts:324](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L324)
 
 Whether the error is likely recoverable (rate limit, timeout, network)

--- a/docs/api/type-aliases/LifecycleFinishPayload.md
+++ b/docs/api/type-aliases/LifecycleFinishPayload.md
@@ -8,7 +8,7 @@
 
 > **LifecycleFinishPayload** = `object`
 
-Defined in: [types/middleware.ts:303](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L303)
+Defined in: [types/middleware.ts:304](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L304)
 
 Payload delivered to onFinish callbacks after generation or streaming completes.
 
@@ -18,7 +18,7 @@ Payload delivered to onFinish callbacks after generation or streaming completes.
 
 > **text**: `string`
 
-Defined in: [types/middleware.ts:305](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L305)
+Defined in: [types/middleware.ts:306](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L306)
 
 The generated text content
 
@@ -28,7 +28,7 @@ The generated text content
 
 > `optional` **usage?**: `object`
 
-Defined in: [types/middleware.ts:307](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L307)
+Defined in: [types/middleware.ts:308](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L308)
 
 Token usage from the provider
 
@@ -46,7 +46,7 @@ Token usage from the provider
 
 > **duration**: `number`
 
-Defined in: [types/middleware.ts:309](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L309)
+Defined in: [types/middleware.ts:310](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L310)
 
 Wall-clock duration in milliseconds
 
@@ -56,6 +56,6 @@ Wall-clock duration in milliseconds
 
 > `optional` **finishReason?**: `string`
 
-Defined in: [types/middleware.ts:311](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L311)
+Defined in: [types/middleware.ts:312](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L312)
 
 Why generation stopped

--- a/docs/api/type-aliases/LifecycleMiddlewareConfig.md
+++ b/docs/api/type-aliases/LifecycleMiddlewareConfig.md
@@ -8,7 +8,7 @@
 
 > **LifecycleMiddlewareConfig** = `object`
 
-Defined in: [types/middleware.ts:357](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L357)
+Defined in: [types/middleware.ts:358](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L358)
 
 Configuration for the lifecycle middleware.
 Pass callbacks to observe generation/streaming lifecycle events.
@@ -19,7 +19,7 @@ Pass callbacks to observe generation/streaming lifecycle events.
 
 > `optional` **onFinish?**: [`OnFinishCallback`](OnFinishCallback.md)
 
-Defined in: [types/middleware.ts:358](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L358)
+Defined in: [types/middleware.ts:359](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L359)
 
 ---
 
@@ -27,7 +27,7 @@ Defined in: [types/middleware.ts:358](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **onError?**: [`OnErrorCallback`](OnErrorCallback.md)
 
-Defined in: [types/middleware.ts:359](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L359)
+Defined in: [types/middleware.ts:360](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L360)
 
 ---
 
@@ -35,7 +35,7 @@ Defined in: [types/middleware.ts:359](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **onChunk?**: [`OnChunkCallback`](OnChunkCallback.md)
 
-Defined in: [types/middleware.ts:360](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L360)
+Defined in: [types/middleware.ts:361](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L361)
 
 ---
 
@@ -43,7 +43,7 @@ Defined in: [types/middleware.ts:360](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **timeoutMs?**: `number`
 
-Defined in: [types/middleware.ts:371](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L371)
+Defined in: [types/middleware.ts:372](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L372)
 
 Per-callback deadline in milliseconds applied to every
 `onChunk` / `onFinish` / `onError` invocation. When a callback

--- a/docs/api/type-aliases/MiddlewareChainConfig.md
+++ b/docs/api/type-aliases/MiddlewareChainConfig.md
@@ -8,7 +8,7 @@
 
 > **MiddlewareChainConfig** = `object`
 
-Defined in: [types/middleware.ts:289](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L289)
+Defined in: [types/middleware.ts:290](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L290)
 
 Middleware chain configuration
 
@@ -18,7 +18,7 @@ Middleware chain configuration
 
 > **middlewares**: [`MiddlewareFactoryConfig`](MiddlewareFactoryConfig.md)[]
 
-Defined in: [types/middleware.ts:290](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L290)
+Defined in: [types/middleware.ts:291](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L291)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/middleware.ts:290](https://github.com/juspay/neurolink/blob/r
 
 > **errorHandling**: `"continue"` \| `"stop"` \| `"rollback"`
 
-Defined in: [types/middleware.ts:291](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L291)
+Defined in: [types/middleware.ts:292](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L292)
 
 ---
 
@@ -34,7 +34,7 @@ Defined in: [types/middleware.ts:291](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **timeout?**: `number`
 
-Defined in: [types/middleware.ts:292](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L292)
+Defined in: [types/middleware.ts:293](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L293)
 
 ---
 
@@ -42,4 +42,4 @@ Defined in: [types/middleware.ts:292](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **retries?**: `number`
 
-Defined in: [types/middleware.ts:293](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L293)
+Defined in: [types/middleware.ts:294](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L294)

--- a/docs/api/type-aliases/MiddlewareChainStats.md
+++ b/docs/api/type-aliases/MiddlewareChainStats.md
@@ -8,7 +8,7 @@
 
 > **MiddlewareChainStats** = `object`
 
-Defined in: [types/middleware.ts:135](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L135)
+Defined in: [types/middleware.ts:136](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L136)
 
 Middleware chain execution statistics
 
@@ -18,7 +18,7 @@ Middleware chain execution statistics
 
 > **totalMiddleware**: `number`
 
-Defined in: [types/middleware.ts:137](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L137)
+Defined in: [types/middleware.ts:138](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L138)
 
 Total number of middleware in the chain
 
@@ -28,7 +28,7 @@ Total number of middleware in the chain
 
 > **appliedMiddleware**: `number`
 
-Defined in: [types/middleware.ts:139](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L139)
+Defined in: [types/middleware.ts:140](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L140)
 
 Number of middleware that were applied
 
@@ -38,7 +38,7 @@ Number of middleware that were applied
 
 > **totalExecutionTime**: `number`
 
-Defined in: [types/middleware.ts:141](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L141)
+Defined in: [types/middleware.ts:142](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L142)
 
 Total execution time for the chain
 
@@ -48,6 +48,6 @@ Total execution time for the chain
 
 > **results**: `Record`\<`string`, [`MiddlewareExecutionResult`](MiddlewareExecutionResult.md)\>
 
-Defined in: [types/middleware.ts:143](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L143)
+Defined in: [types/middleware.ts:144](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L144)
 
 Individual middleware execution results

--- a/docs/api/type-aliases/MiddlewareConditions.md
+++ b/docs/api/type-aliases/MiddlewareConditions.md
@@ -8,7 +8,7 @@
 
 > **MiddlewareConditions** = `object`
 
-Defined in: [types/middleware.ts:76](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L76)
+Defined in: [types/middleware.ts:77](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L77)
 
 Conditions for applying middleware
 
@@ -18,7 +18,7 @@ Conditions for applying middleware
 
 > `optional` **providers?**: `string`[]
 
-Defined in: [types/middleware.ts:78](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L78)
+Defined in: [types/middleware.ts:79](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L79)
 
 Apply only to specific providers
 
@@ -28,7 +28,7 @@ Apply only to specific providers
 
 > `optional` **models?**: `string`[]
 
-Defined in: [types/middleware.ts:80](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L80)
+Defined in: [types/middleware.ts:81](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L81)
 
 Apply only to specific models
 
@@ -38,7 +38,7 @@ Apply only to specific models
 
 > `optional` **options?**: `Record`\<`string`, `unknown`\>
 
-Defined in: [types/middleware.ts:82](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L82)
+Defined in: [types/middleware.ts:83](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L83)
 
 Apply only when certain options are present
 
@@ -48,7 +48,7 @@ Apply only when certain options are present
 
 > `optional` **custom?**: (`context`) => `boolean`
 
-Defined in: [types/middleware.ts:84](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L84)
+Defined in: [types/middleware.ts:85](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L85)
 
 Custom condition function
 

--- a/docs/api/type-aliases/MiddlewareConfig.md
+++ b/docs/api/type-aliases/MiddlewareConfig.md
@@ -8,7 +8,7 @@
 
 > **MiddlewareConfig** = `object`
 
-Defined in: [types/middleware.ts:64](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L64)
+Defined in: [types/middleware.ts:65](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L65)
 
 Middleware configuration options
 
@@ -18,7 +18,7 @@ Middleware configuration options
 
 > `optional` **enabled?**: `boolean`
 
-Defined in: [types/middleware.ts:66](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L66)
+Defined in: [types/middleware.ts:67](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L67)
 
 Whether the middleware is enabled
 
@@ -28,7 +28,7 @@ Whether the middleware is enabled
 
 > `optional` **config?**: `Record`\<`string`, `unknown`\>
 
-Defined in: [types/middleware.ts:68](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L68)
+Defined in: [types/middleware.ts:69](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L69)
 
 Middleware-specific configuration
 
@@ -38,6 +38,6 @@ Middleware-specific configuration
 
 > `optional` **conditions?**: [`MiddlewareConditions`](MiddlewareConditions.md)
 
-Defined in: [types/middleware.ts:70](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L70)
+Defined in: [types/middleware.ts:71](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L71)
 
 Conditions under which to apply this middleware

--- a/docs/api/type-aliases/MiddlewareContext.md
+++ b/docs/api/type-aliases/MiddlewareContext.md
@@ -8,7 +8,7 @@
 
 > **MiddlewareContext** = `object`
 
-Defined in: [types/middleware.ts:90](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L90)
+Defined in: [types/middleware.ts:91](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L91)
 
 Context passed to middleware for decision making
 
@@ -18,7 +18,7 @@ Context passed to middleware for decision making
 
 > **provider**: `string`
 
-Defined in: [types/middleware.ts:92](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L92)
+Defined in: [types/middleware.ts:93](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L93)
 
 Provider name
 
@@ -28,7 +28,7 @@ Provider name
 
 > **model**: `string`
 
-Defined in: [types/middleware.ts:94](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L94)
+Defined in: [types/middleware.ts:95](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L95)
 
 Model name
 
@@ -38,7 +38,7 @@ Model name
 
 > **options**: `Record`\<`string`, `unknown`\>
 
-Defined in: [types/middleware.ts:96](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L96)
+Defined in: [types/middleware.ts:97](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L97)
 
 Request options
 
@@ -48,7 +48,7 @@ Request options
 
 > `optional` **session?**: `object`
 
-Defined in: [types/middleware.ts:98](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L98)
+Defined in: [types/middleware.ts:99](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L99)
 
 Session information
 
@@ -66,6 +66,6 @@ Session information
 
 > `optional` **metadata?**: `Record`\<`string`, [`JsonValue`](JsonValue.md)\>
 
-Defined in: [types/middleware.ts:103](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L103)
+Defined in: [types/middleware.ts:104](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L104)
 
 Additional metadata

--- a/docs/api/type-aliases/MiddlewareExecutionContext.md
+++ b/docs/api/type-aliases/MiddlewareExecutionContext.md
@@ -8,7 +8,7 @@
 
 > **MiddlewareExecutionContext** = `object`
 
-Defined in: [types/middleware.ts:264](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L264)
+Defined in: [types/middleware.ts:265](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L265)
 
 Middleware execution context
 
@@ -18,7 +18,7 @@ Middleware execution context
 
 > **requestId**: `string`
 
-Defined in: [types/middleware.ts:265](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L265)
+Defined in: [types/middleware.ts:266](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L266)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/middleware.ts:265](https://github.com/juspay/neurolink/blob/r
 
 > **timestamp**: `number`
 
-Defined in: [types/middleware.ts:266](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L266)
+Defined in: [types/middleware.ts:267](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L267)
 
 ---
 
@@ -34,7 +34,7 @@ Defined in: [types/middleware.ts:266](https://github.com/juspay/neurolink/blob/r
 
 > **provider**: `string`
 
-Defined in: [types/middleware.ts:267](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L267)
+Defined in: [types/middleware.ts:268](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L268)
 
 ---
 
@@ -42,7 +42,7 @@ Defined in: [types/middleware.ts:267](https://github.com/juspay/neurolink/blob/r
 
 > **model**: `string`
 
-Defined in: [types/middleware.ts:268](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L268)
+Defined in: [types/middleware.ts:269](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L269)
 
 ---
 
@@ -50,7 +50,7 @@ Defined in: [types/middleware.ts:268](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **userId?**: `string`
 
-Defined in: [types/middleware.ts:269](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L269)
+Defined in: [types/middleware.ts:270](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L270)
 
 ---
 
@@ -58,7 +58,7 @@ Defined in: [types/middleware.ts:269](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **sessionId?**: `string`
 
-Defined in: [types/middleware.ts:270](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L270)
+Defined in: [types/middleware.ts:271](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L271)
 
 ---
 
@@ -66,4 +66,4 @@ Defined in: [types/middleware.ts:270](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **metadata?**: `Record`\<`string`, `unknown`\>
 
-Defined in: [types/middleware.ts:271](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L271)
+Defined in: [types/middleware.ts:272](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L272)

--- a/docs/api/type-aliases/MiddlewareExecutionResult.md
+++ b/docs/api/type-aliases/MiddlewareExecutionResult.md
@@ -8,7 +8,7 @@
 
 > **MiddlewareExecutionResult** = `object`
 
-Defined in: [types/middleware.ts:121](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L121)
+Defined in: [types/middleware.ts:122](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L122)
 
 Middleware execution result
 
@@ -18,7 +18,7 @@ Middleware execution result
 
 > **applied**: `boolean`
 
-Defined in: [types/middleware.ts:123](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L123)
+Defined in: [types/middleware.ts:124](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L124)
 
 Whether the middleware was applied
 
@@ -28,7 +28,7 @@ Whether the middleware was applied
 
 > **executionTime**: `number`
 
-Defined in: [types/middleware.ts:125](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L125)
+Defined in: [types/middleware.ts:126](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L126)
 
 Execution time in milliseconds
 
@@ -38,7 +38,7 @@ Execution time in milliseconds
 
 > `optional` **error?**: `Error`
 
-Defined in: [types/middleware.ts:127](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L127)
+Defined in: [types/middleware.ts:128](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L128)
 
 Any errors that occurred
 
@@ -48,6 +48,6 @@ Any errors that occurred
 
 > `optional` **metadata?**: `Record`\<`string`, [`JsonValue`](JsonValue.md)\>
 
-Defined in: [types/middleware.ts:129](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L129)
+Defined in: [types/middleware.ts:130](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L130)
 
 Additional metadata from the middleware

--- a/docs/api/type-aliases/MiddlewareFactoryConfig.md
+++ b/docs/api/type-aliases/MiddlewareFactoryConfig.md
@@ -8,7 +8,7 @@
 
 > **MiddlewareFactoryConfig** = `object`
 
-Defined in: [types/middleware.ts:227](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L227)
+Defined in: [types/middleware.ts:228](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L228)
 
 Middleware factory configuration options
 
@@ -18,7 +18,7 @@ Middleware factory configuration options
 
 > **enabled**: `boolean`
 
-Defined in: [types/middleware.ts:228](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L228)
+Defined in: [types/middleware.ts:229](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L229)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/middleware.ts:228](https://github.com/juspay/neurolink/blob/r
 
 > **type**: `string`
 
-Defined in: [types/middleware.ts:229](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L229)
+Defined in: [types/middleware.ts:230](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L230)
 
 ---
 
@@ -34,7 +34,7 @@ Defined in: [types/middleware.ts:229](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **priority?**: `number`
 
-Defined in: [types/middleware.ts:230](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L230)
+Defined in: [types/middleware.ts:231](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L231)
 
 ---
 
@@ -42,4 +42,4 @@ Defined in: [types/middleware.ts:230](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **config?**: `Record`\<`string`, `unknown`\>
 
-Defined in: [types/middleware.ts:231](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L231)
+Defined in: [types/middleware.ts:232](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L232)

--- a/docs/api/type-aliases/MiddlewareFactoryOptions.md
+++ b/docs/api/type-aliases/MiddlewareFactoryOptions.md
@@ -8,7 +8,7 @@
 
 > **MiddlewareFactoryOptions** = `object`
 
-Defined in: [types/middleware.ts:175](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L175)
+Defined in: [types/middleware.ts:176](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L176)
 
 Factory options for middleware
 
@@ -18,7 +18,7 @@ Factory options for middleware
 
 > `optional` **middleware?**: [`NeuroLinkMiddleware`](NeuroLinkMiddleware.md)[]
 
-Defined in: [types/middleware.ts:177](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L177)
+Defined in: [types/middleware.ts:178](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L178)
 
 Custom middleware to register on initialization
 
@@ -28,7 +28,7 @@ Custom middleware to register on initialization
 
 > `optional` **enabledMiddleware?**: `string`[]
 
-Defined in: [types/middleware.ts:179](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L179)
+Defined in: [types/middleware.ts:180](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L180)
 
 Enable specific middleware
 
@@ -38,7 +38,7 @@ Enable specific middleware
 
 > `optional` **disabledMiddleware?**: `string`[]
 
-Defined in: [types/middleware.ts:181](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L181)
+Defined in: [types/middleware.ts:182](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L182)
 
 Disable specific middleware
 
@@ -48,7 +48,7 @@ Disable specific middleware
 
 > `optional` **middlewareConfig?**: `Record`\<`string`, [`MiddlewareConfig`](MiddlewareConfig.md)\>
 
-Defined in: [types/middleware.ts:183](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L183)
+Defined in: [types/middleware.ts:184](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L184)
 
 Middleware configurations
 
@@ -58,7 +58,7 @@ Middleware configurations
 
 > `optional` **preset?**: `string`
 
-Defined in: [types/middleware.ts:185](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L185)
+Defined in: [types/middleware.ts:186](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L186)
 
 Use a preset configuration
 
@@ -68,7 +68,7 @@ Use a preset configuration
 
 > `optional` **global?**: `object`
 
-Defined in: [types/middleware.ts:187](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L187)
+Defined in: [types/middleware.ts:188](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L188)
 
 Global middleware settings
 

--- a/docs/api/type-aliases/MiddlewareMetrics.md
+++ b/docs/api/type-aliases/MiddlewareMetrics.md
@@ -8,7 +8,7 @@
 
 > **MiddlewareMetrics** = `object`
 
-Defined in: [types/middleware.ts:277](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L277)
+Defined in: [types/middleware.ts:278](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L278)
 
 Middleware performance metrics
 
@@ -18,7 +18,7 @@ Middleware performance metrics
 
 > **name**: `string`
 
-Defined in: [types/middleware.ts:278](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L278)
+Defined in: [types/middleware.ts:279](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L279)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/middleware.ts:278](https://github.com/juspay/neurolink/blob/r
 
 > **executionTime**: `number`
 
-Defined in: [types/middleware.ts:279](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L279)
+Defined in: [types/middleware.ts:280](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L280)
 
 ---
 
@@ -34,7 +34,7 @@ Defined in: [types/middleware.ts:279](https://github.com/juspay/neurolink/blob/r
 
 > **status**: `"success"` \| `"error"` \| `"skipped"`
 
-Defined in: [types/middleware.ts:280](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L280)
+Defined in: [types/middleware.ts:281](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L281)
 
 ---
 
@@ -42,7 +42,7 @@ Defined in: [types/middleware.ts:280](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **error?**: `string`
 
-Defined in: [types/middleware.ts:281](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L281)
+Defined in: [types/middleware.ts:282](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L282)
 
 ---
 
@@ -50,7 +50,7 @@ Defined in: [types/middleware.ts:281](https://github.com/juspay/neurolink/blob/r
 
 > **inputSize**: `number`
 
-Defined in: [types/middleware.ts:282](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L282)
+Defined in: [types/middleware.ts:283](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L283)
 
 ---
 
@@ -58,4 +58,4 @@ Defined in: [types/middleware.ts:282](https://github.com/juspay/neurolink/blob/r
 
 > **outputSize**: `number`
 
-Defined in: [types/middleware.ts:283](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L283)
+Defined in: [types/middleware.ts:284](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L284)

--- a/docs/api/type-aliases/MiddlewarePreset.md
+++ b/docs/api/type-aliases/MiddlewarePreset.md
@@ -8,7 +8,7 @@
 
 > **MiddlewarePreset** = `object`
 
-Defined in: [types/middleware.ts:163](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L163)
+Defined in: [types/middleware.ts:164](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L164)
 
 Middleware preset configurations
 
@@ -18,7 +18,7 @@ Middleware preset configurations
 
 > **name**: `string`
 
-Defined in: [types/middleware.ts:165](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L165)
+Defined in: [types/middleware.ts:166](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L166)
 
 Preset name
 
@@ -28,7 +28,7 @@ Preset name
 
 > **description**: `string`
 
-Defined in: [types/middleware.ts:167](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L167)
+Defined in: [types/middleware.ts:168](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L168)
 
 Description of the preset
 
@@ -38,6 +38,6 @@ Description of the preset
 
 > **config**: `Record`\<`string`, [`MiddlewareConfig`](MiddlewareConfig.md)\>
 
-Defined in: [types/middleware.ts:169](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L169)
+Defined in: [types/middleware.ts:170](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L170)
 
 Middleware configurations in the preset

--- a/docs/api/type-aliases/MiddlewareRegistrationOptions.md
+++ b/docs/api/type-aliases/MiddlewareRegistrationOptions.md
@@ -8,7 +8,7 @@
 
 > **MiddlewareRegistrationOptions** = `object`
 
-Defined in: [types/middleware.ts:109](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L109)
+Defined in: [types/middleware.ts:110](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L110)
 
 Middleware registration options
 
@@ -18,7 +18,7 @@ Middleware registration options
 
 > `optional` **replace?**: `boolean`
 
-Defined in: [types/middleware.ts:111](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L111)
+Defined in: [types/middleware.ts:112](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L112)
 
 Whether to replace existing middleware with same ID
 
@@ -28,7 +28,7 @@ Whether to replace existing middleware with same ID
 
 > `optional` **defaultEnabled?**: `boolean`
 
-Defined in: [types/middleware.ts:113](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L113)
+Defined in: [types/middleware.ts:114](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L114)
 
 Whether to enable the middleware by default
 
@@ -38,6 +38,6 @@ Whether to enable the middleware by default
 
 > `optional` **globalConfig?**: `Record`\<`string`, [`JsonValue`](JsonValue.md)\>
 
-Defined in: [types/middleware.ts:115](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L115)
+Defined in: [types/middleware.ts:116](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L116)
 
 Global configuration for the middleware

--- a/docs/api/type-aliases/MiddlewareRegistryEntry.md
+++ b/docs/api/type-aliases/MiddlewareRegistryEntry.md
@@ -8,7 +8,7 @@
 
 > **MiddlewareRegistryEntry** = `object`
 
-Defined in: [types/middleware.ts:237](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L237)
+Defined in: [types/middleware.ts:238](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L238)
 
 Middleware registry entry
 
@@ -18,7 +18,7 @@ Middleware registry entry
 
 > **name**: `string`
 
-Defined in: [types/middleware.ts:238](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L238)
+Defined in: [types/middleware.ts:239](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L239)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/middleware.ts:238](https://github.com/juspay/neurolink/blob/r
 
 > **factory**: `MiddlewareFactory`
 
-Defined in: [types/middleware.ts:239](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L239)
+Defined in: [types/middleware.ts:240](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L240)
 
 ---
 
@@ -34,7 +34,7 @@ Defined in: [types/middleware.ts:239](https://github.com/juspay/neurolink/blob/r
 
 > **defaultConfig**: `Record`\<`string`, `unknown`\>
 
-Defined in: [types/middleware.ts:240](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L240)
+Defined in: [types/middleware.ts:241](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L241)
 
 ---
 
@@ -42,7 +42,7 @@ Defined in: [types/middleware.ts:240](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **description?**: `string`
 
-Defined in: [types/middleware.ts:241](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L241)
+Defined in: [types/middleware.ts:242](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L242)
 
 ---
 
@@ -50,4 +50,4 @@ Defined in: [types/middleware.ts:241](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **version?**: `string`
 
-Defined in: [types/middleware.ts:242](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L242)
+Defined in: [types/middleware.ts:243](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L243)

--- a/docs/api/type-aliases/MiddlewareRequestSchema.md
+++ b/docs/api/type-aliases/MiddlewareRequestSchema.md
@@ -8,7 +8,7 @@
 
 > **MiddlewareRequestSchema** = `object`
 
-Defined in: [types/middleware.ts:493](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L493)
+Defined in: [types/middleware.ts:494](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L494)
 
 Simple structural validation schema used by the request-validation
 middleware. Named MiddlewareRequestSchema to disambiguate from the zod
@@ -20,7 +20,7 @@ middleware. Named MiddlewareRequestSchema to disambiguate from the zod
 
 > `optional` **required?**: `string`[]
 
-Defined in: [types/middleware.ts:494](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L494)
+Defined in: [types/middleware.ts:495](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L495)
 
 ---
 
@@ -28,7 +28,7 @@ Defined in: [types/middleware.ts:494](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **properties?**: `Record`\<`string`, [`PropertySchema`](PropertySchema.md)\>
 
-Defined in: [types/middleware.ts:495](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L495)
+Defined in: [types/middleware.ts:496](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L496)
 
 ---
 
@@ -36,4 +36,4 @@ Defined in: [types/middleware.ts:495](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **additionalProperties?**: `boolean`
 
-Defined in: [types/middleware.ts:496](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L496)
+Defined in: [types/middleware.ts:497](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L497)

--- a/docs/api/type-aliases/MiddlewareValidationResult.md
+++ b/docs/api/type-aliases/MiddlewareValidationResult.md
@@ -8,7 +8,7 @@
 
 > **MiddlewareValidationResult** = `object`
 
-Defined in: [types/middleware.ts:255](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L255)
+Defined in: [types/middleware.ts:256](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L256)
 
 Middleware validation result
 
@@ -18,7 +18,7 @@ Middleware validation result
 
 > **valid**: `boolean`
 
-Defined in: [types/middleware.ts:256](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L256)
+Defined in: [types/middleware.ts:257](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L257)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/middleware.ts:256](https://github.com/juspay/neurolink/blob/r
 
 > **errors**: `string`[]
 
-Defined in: [types/middleware.ts:257](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L257)
+Defined in: [types/middleware.ts:258](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L258)
 
 ---
 
@@ -34,4 +34,4 @@ Defined in: [types/middleware.ts:257](https://github.com/juspay/neurolink/blob/r
 
 > **warnings**: `string`[]
 
-Defined in: [types/middleware.ts:258](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L258)
+Defined in: [types/middleware.ts:259](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L259)

--- a/docs/api/type-aliases/NeuroLinkMiddleware.md
+++ b/docs/api/type-aliases/NeuroLinkMiddleware.md
@@ -8,7 +8,7 @@
 
 > **NeuroLinkMiddleware** = [`LanguageModelMiddleware`](LanguageModelMiddleware.md) & `object`
 
-Defined in: [types/middleware.ts:56](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L56)
+Defined in: [types/middleware.ts:57](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L57)
 
 NeuroLink middleware with metadata
 Combines standard AI SDK middleware with NeuroLink-specific metadata

--- a/docs/api/type-aliases/NeuroLinkMiddlewareMetadata.md
+++ b/docs/api/type-aliases/NeuroLinkMiddlewareMetadata.md
@@ -8,7 +8,7 @@
 
 > **NeuroLinkMiddlewareMetadata** = `object`
 
-Defined in: [types/middleware.ts:37](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L37)
+Defined in: [types/middleware.ts:38](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L38)
 
 Metadata type for NeuroLink middleware
 Provides additional information about middleware without affecting execution
@@ -19,7 +19,7 @@ Provides additional information about middleware without affecting execution
 
 > **id**: `string`
 
-Defined in: [types/middleware.ts:39](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L39)
+Defined in: [types/middleware.ts:40](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L40)
 
 Unique identifier for the middleware
 
@@ -29,7 +29,7 @@ Unique identifier for the middleware
 
 > **name**: `string`
 
-Defined in: [types/middleware.ts:41](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L41)
+Defined in: [types/middleware.ts:42](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L42)
 
 Human-readable name
 
@@ -39,7 +39,7 @@ Human-readable name
 
 > `optional` **description?**: `string`
 
-Defined in: [types/middleware.ts:43](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L43)
+Defined in: [types/middleware.ts:44](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L44)
 
 Description of what the middleware does
 
@@ -49,7 +49,7 @@ Description of what the middleware does
 
 > `optional` **priority?**: `number`
 
-Defined in: [types/middleware.ts:45](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L45)
+Defined in: [types/middleware.ts:46](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L46)
 
 Priority for ordering (higher = earlier in chain)
 
@@ -59,7 +59,7 @@ Priority for ordering (higher = earlier in chain)
 
 > `optional` **defaultEnabled?**: `boolean`
 
-Defined in: [types/middleware.ts:47](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L47)
+Defined in: [types/middleware.ts:48](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L48)
 
 Whether this middleware is enabled by default
 
@@ -69,6 +69,6 @@ Whether this middleware is enabled by default
 
 > `optional` **configSchema?**: `Record`\<`string`, `unknown`\>
 
-Defined in: [types/middleware.ts:49](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L49)
+Defined in: [types/middleware.ts:50](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L50)
 
 Configuration schema for the middleware

--- a/docs/api/type-aliases/OnChunkCallback.md
+++ b/docs/api/type-aliases/OnChunkCallback.md
@@ -8,7 +8,7 @@
 
 > **OnChunkCallback** = (`payload`) => `void` \| `Promise`\<`void`\>
 
-Defined in: [types/middleware.ts:349](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L349)
+Defined in: [types/middleware.ts:350](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L350)
 
 Callback invoked for each chunk during streaming.
 

--- a/docs/api/type-aliases/OnErrorCallback.md
+++ b/docs/api/type-aliases/OnErrorCallback.md
@@ -8,7 +8,7 @@
 
 > **OnErrorCallback** = (`payload`) => `void` \| `Promise`\<`void`\>
 
-Defined in: [types/middleware.ts:344](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L344)
+Defined in: [types/middleware.ts:345](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L345)
 
 Callback invoked when generation or streaming encounters an error.
 

--- a/docs/api/type-aliases/OnFinishCallback.md
+++ b/docs/api/type-aliases/OnFinishCallback.md
@@ -8,7 +8,7 @@
 
 > **OnFinishCallback** = (`payload`) => `void` \| `Promise`\<`void`\>
 
-Defined in: [types/middleware.ts:339](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L339)
+Defined in: [types/middleware.ts:340](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L340)
 
 Callback invoked when generation or streaming finishes successfully.
 

--- a/docs/api/type-aliases/OptionsWithLifecycleMiddleware.md
+++ b/docs/api/type-aliases/OptionsWithLifecycleMiddleware.md
@@ -8,7 +8,7 @@
 
 > **OptionsWithLifecycleMiddleware** = `object`
 
-Defined in: [types/middleware.ts:381](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L381)
+Defined in: [types/middleware.ts:382](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L382)
 
 Structural view of the nested lifecycle config buried inside a request's
 middleware blob. Extracted so call sites that need to read it (e.g.
@@ -22,7 +22,7 @@ three-level cast.
 
 > `optional` **middleware?**: `object`
 
-Defined in: [types/middleware.ts:382](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L382)
+Defined in: [types/middleware.ts:383](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L383)
 
 #### middlewareConfig?
 

--- a/docs/api/type-aliases/PropertySchema.md
+++ b/docs/api/type-aliases/PropertySchema.md
@@ -8,7 +8,7 @@
 
 > **PropertySchema** = `object`
 
-Defined in: [types/middleware.ts:500](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L500)
+Defined in: [types/middleware.ts:501](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L501)
 
 Schema for an individual property in ValidationSchema.
 
@@ -18,7 +18,7 @@ Schema for an individual property in ValidationSchema.
 
 > **type**: `"string"` \| `"number"` \| `"boolean"` \| `"object"` \| `"array"`
 
-Defined in: [types/middleware.ts:501](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L501)
+Defined in: [types/middleware.ts:502](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L502)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/middleware.ts:501](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **minimum?**: `number`
 
-Defined in: [types/middleware.ts:502](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L502)
+Defined in: [types/middleware.ts:503](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L503)
 
 ---
 
@@ -34,7 +34,7 @@ Defined in: [types/middleware.ts:502](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **maximum?**: `number`
 
-Defined in: [types/middleware.ts:503](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L503)
+Defined in: [types/middleware.ts:504](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L504)
 
 ---
 
@@ -42,7 +42,7 @@ Defined in: [types/middleware.ts:503](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **minLength?**: `number`
 
-Defined in: [types/middleware.ts:504](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L504)
+Defined in: [types/middleware.ts:505](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L505)
 
 ---
 
@@ -50,7 +50,7 @@ Defined in: [types/middleware.ts:504](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **maxLength?**: `number`
 
-Defined in: [types/middleware.ts:505](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L505)
+Defined in: [types/middleware.ts:506](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L506)
 
 ---
 
@@ -58,7 +58,7 @@ Defined in: [types/middleware.ts:505](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **minItems?**: `number`
 
-Defined in: [types/middleware.ts:506](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L506)
+Defined in: [types/middleware.ts:507](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L507)
 
 ---
 
@@ -66,7 +66,7 @@ Defined in: [types/middleware.ts:506](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **maxItems?**: `number`
 
-Defined in: [types/middleware.ts:507](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L507)
+Defined in: [types/middleware.ts:508](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L508)
 
 ---
 
@@ -74,7 +74,7 @@ Defined in: [types/middleware.ts:507](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **pattern?**: `string`
 
-Defined in: [types/middleware.ts:508](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L508)
+Defined in: [types/middleware.ts:509](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L509)
 
 ---
 
@@ -82,7 +82,7 @@ Defined in: [types/middleware.ts:508](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **enum?**: `unknown`[]
 
-Defined in: [types/middleware.ts:509](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L509)
+Defined in: [types/middleware.ts:510](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L510)
 
 ---
 
@@ -90,7 +90,7 @@ Defined in: [types/middleware.ts:509](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **default?**: `unknown`
 
-Defined in: [types/middleware.ts:510](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L510)
+Defined in: [types/middleware.ts:511](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L511)
 
 ---
 
@@ -98,7 +98,7 @@ Defined in: [types/middleware.ts:510](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **validate?**: (`value`) => `boolean` \| `string`
 
-Defined in: [types/middleware.ts:511](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L511)
+Defined in: [types/middleware.ts:512](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L512)
 
 #### Parameters
 

--- a/docs/api/type-aliases/RateLimitEntry.md
+++ b/docs/api/type-aliases/RateLimitEntry.md
@@ -8,7 +8,7 @@
 
 > **RateLimitEntry** = `object`
 
-Defined in: [types/middleware.ts:438](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L438)
+Defined in: [types/middleware.ts:439](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L439)
 
 Rate-limit counter entry tracked per key.
 
@@ -18,7 +18,7 @@ Rate-limit counter entry tracked per key.
 
 > **count**: `number`
 
-Defined in: [types/middleware.ts:439](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L439)
+Defined in: [types/middleware.ts:440](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L440)
 
 ---
 
@@ -26,4 +26,4 @@ Defined in: [types/middleware.ts:439](https://github.com/juspay/neurolink/blob/r
 
 > **resetAt**: `number`
 
-Defined in: [types/middleware.ts:440](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L440)
+Defined in: [types/middleware.ts:441](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L441)

--- a/docs/api/type-aliases/RateLimitMiddlewareConfig.md
+++ b/docs/api/type-aliases/RateLimitMiddlewareConfig.md
@@ -8,7 +8,7 @@
 
 > **RateLimitMiddlewareConfig** = `object`
 
-Defined in: [types/middleware.ts:427](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L427)
+Defined in: [types/middleware.ts:428](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L428)
 
 Rate-limit middleware configuration.
 
@@ -18,7 +18,7 @@ Rate-limit middleware configuration.
 
 > **maxRequests**: `number`
 
-Defined in: [types/middleware.ts:428](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L428)
+Defined in: [types/middleware.ts:429](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L429)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/middleware.ts:428](https://github.com/juspay/neurolink/blob/r
 
 > **windowMs**: `number`
 
-Defined in: [types/middleware.ts:429](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L429)
+Defined in: [types/middleware.ts:430](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L430)
 
 ---
 
@@ -34,7 +34,7 @@ Defined in: [types/middleware.ts:429](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **message?**: `string`
 
-Defined in: [types/middleware.ts:430](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L430)
+Defined in: [types/middleware.ts:431](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L431)
 
 ---
 
@@ -42,7 +42,7 @@ Defined in: [types/middleware.ts:430](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **skipPaths?**: `string`[]
 
-Defined in: [types/middleware.ts:431](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L431)
+Defined in: [types/middleware.ts:432](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L432)
 
 ---
 
@@ -50,7 +50,7 @@ Defined in: [types/middleware.ts:431](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **keyGenerator?**: (`ctx`) => `string`
 
-Defined in: [types/middleware.ts:432](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L432)
+Defined in: [types/middleware.ts:433](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L433)
 
 #### Parameters
 
@@ -68,7 +68,7 @@ Defined in: [types/middleware.ts:432](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **onRateLimitExceeded?**: (`ctx`, `retryAfter`) => `unknown`
 
-Defined in: [types/middleware.ts:433](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L433)
+Defined in: [types/middleware.ts:434](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L434)
 
 #### Parameters
 
@@ -90,4 +90,4 @@ Defined in: [types/middleware.ts:433](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **store?**: [`RateLimitStore`](RateLimitStore.md)
 
-Defined in: [types/middleware.ts:434](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L434)
+Defined in: [types/middleware.ts:435](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L435)

--- a/docs/api/type-aliases/RateLimitStore.md
+++ b/docs/api/type-aliases/RateLimitStore.md
@@ -8,7 +8,7 @@
 
 > **RateLimitStore** = `object`
 
-Defined in: [types/middleware.ts:444](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L444)
+Defined in: [types/middleware.ts:445](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L445)
 
 Rate-limit store contract (memory or Redis).
 
@@ -18,7 +18,7 @@ Rate-limit store contract (memory or Redis).
 
 > **get**(`key`): `Promise`\<[`RateLimitEntry`](RateLimitEntry.md) \| `undefined`\>
 
-Defined in: [types/middleware.ts:445](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L445)
+Defined in: [types/middleware.ts:446](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L446)
 
 #### Parameters
 
@@ -36,7 +36,7 @@ Defined in: [types/middleware.ts:445](https://github.com/juspay/neurolink/blob/r
 
 > **set**(`key`, `entry`): `Promise`\<`void`\>
 
-Defined in: [types/middleware.ts:446](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L446)
+Defined in: [types/middleware.ts:447](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L447)
 
 #### Parameters
 
@@ -58,7 +58,7 @@ Defined in: [types/middleware.ts:446](https://github.com/juspay/neurolink/blob/r
 
 > **increment**(`key`, `windowMs`): `Promise`\<[`RateLimitEntry`](RateLimitEntry.md)\>
 
-Defined in: [types/middleware.ts:447](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L447)
+Defined in: [types/middleware.ts:448](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L448)
 
 #### Parameters
 
@@ -80,7 +80,7 @@ Defined in: [types/middleware.ts:447](https://github.com/juspay/neurolink/blob/r
 
 > **reset**(`key`): `Promise`\<`void`\>
 
-Defined in: [types/middleware.ts:448](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L448)
+Defined in: [types/middleware.ts:449](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L449)
 
 #### Parameters
 

--- a/docs/api/type-aliases/TokenValidator.md
+++ b/docs/api/type-aliases/TokenValidator.md
@@ -8,7 +8,7 @@
 
 > **TokenValidator** = (`token`) => `Promise`\<[`AuthenticatedUser`](AuthenticatedUser.md) \| `null`\> \| [`AuthenticatedUser`](AuthenticatedUser.md) \| `null`
 
-Defined in: [types/middleware.ts:409](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L409)
+Defined in: [types/middleware.ts:410](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L410)
 
 Token-validation function signature.
 

--- a/docs/api/type-aliases/ValidationConfig.md
+++ b/docs/api/type-aliases/ValidationConfig.md
@@ -8,7 +8,7 @@
 
 > **ValidationConfig** = `object`
 
-Defined in: [types/middleware.ts:478](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L478)
+Defined in: [types/middleware.ts:479](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L479)
 
 Validation configuration for the request-validation middleware.
 
@@ -18,7 +18,7 @@ Validation configuration for the request-validation middleware.
 
 > `optional` **bodySchema?**: [`MiddlewareRequestSchema`](MiddlewareRequestSchema.md)
 
-Defined in: [types/middleware.ts:479](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L479)
+Defined in: [types/middleware.ts:480](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L480)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/middleware.ts:479](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **querySchema?**: [`MiddlewareRequestSchema`](MiddlewareRequestSchema.md)
 
-Defined in: [types/middleware.ts:480](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L480)
+Defined in: [types/middleware.ts:481](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L481)
 
 ---
 
@@ -34,7 +34,7 @@ Defined in: [types/middleware.ts:480](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **paramsSchema?**: [`MiddlewareRequestSchema`](MiddlewareRequestSchema.md)
 
-Defined in: [types/middleware.ts:481](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L481)
+Defined in: [types/middleware.ts:482](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L482)
 
 ---
 
@@ -42,7 +42,7 @@ Defined in: [types/middleware.ts:481](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **headersSchema?**: [`MiddlewareRequestSchema`](MiddlewareRequestSchema.md)
 
-Defined in: [types/middleware.ts:482](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L482)
+Defined in: [types/middleware.ts:483](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L483)
 
 ---
 
@@ -50,7 +50,7 @@ Defined in: [types/middleware.ts:482](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **customValidator?**: (`ctx`) => `Promise`\<`void`\>
 
-Defined in: [types/middleware.ts:483](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L483)
+Defined in: [types/middleware.ts:484](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L484)
 
 #### Parameters
 
@@ -68,7 +68,7 @@ Defined in: [types/middleware.ts:483](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **skipPaths?**: `string`[]
 
-Defined in: [types/middleware.ts:484](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L484)
+Defined in: [types/middleware.ts:485](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L485)
 
 ---
 
@@ -76,7 +76,7 @@ Defined in: [types/middleware.ts:484](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **errorFormatter?**: (`errors`) => `unknown`
 
-Defined in: [types/middleware.ts:485](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L485)
+Defined in: [types/middleware.ts:486](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L486)
 
 #### Parameters
 

--- a/docs/api/type-aliases/ValidationErrorInfo.md
+++ b/docs/api/type-aliases/ValidationErrorInfo.md
@@ -8,7 +8,7 @@
 
 > **ValidationErrorInfo** = `object`
 
-Defined in: [types/middleware.ts:472](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L472)
+Defined in: [types/middleware.ts:473](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L473)
 
 Minimal structural view of the server-side ValidationError class used by
 the request-validation middleware's errorFormatter callback.
@@ -19,7 +19,7 @@ the request-validation middleware's errorFormatter callback.
 
 > **errors**: [`ValidationErrorPayload`](ValidationErrorPayload.md)[]
 
-Defined in: [types/middleware.ts:473](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L473)
+Defined in: [types/middleware.ts:474](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L474)
 
 ---
 
@@ -27,4 +27,4 @@ Defined in: [types/middleware.ts:473](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **requestId?**: `string`
 
-Defined in: [types/middleware.ts:474](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L474)
+Defined in: [types/middleware.ts:475](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L475)

--- a/docs/api/type-aliases/ValidationErrorPayload.md
+++ b/docs/api/type-aliases/ValidationErrorPayload.md
@@ -8,7 +8,7 @@
 
 > **ValidationErrorPayload** = `object`
 
-Defined in: [types/middleware.ts:462](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L462)
+Defined in: [types/middleware.ts:463](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L463)
 
 Per-field entry inside a ServerValidationError's `errors` array.
 
@@ -18,7 +18,7 @@ Per-field entry inside a ServerValidationError's `errors` array.
 
 > **field**: `string`
 
-Defined in: [types/middleware.ts:463](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L463)
+Defined in: [types/middleware.ts:464](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L464)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [types/middleware.ts:463](https://github.com/juspay/neurolink/blob/r
 
 > **message**: `string`
 
-Defined in: [types/middleware.ts:464](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L464)
+Defined in: [types/middleware.ts:465](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L465)
 
 ---
 
@@ -34,4 +34,4 @@ Defined in: [types/middleware.ts:464](https://github.com/juspay/neurolink/blob/r
 
 > `optional` **value?**: `unknown`
 
-Defined in: [types/middleware.ts:465](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L465)
+Defined in: [types/middleware.ts:466](https://github.com/juspay/neurolink/blob/release/src/lib/types/middleware.ts#L466)

--- a/src/lib/middleware/builtin/guardrails.ts
+++ b/src/lib/middleware/builtin/guardrails.ts
@@ -3,6 +3,8 @@ import type {
   NeuroLinkMiddlewareMetadata,
   GuardrailsMiddlewareConfig,
   LanguageModelV3StreamPart,
+  BadWordsConfig,
+  LanguageModelV3Content,
 } from "../../types/index.js";
 import {
   createBlockedResponse,
@@ -13,6 +15,48 @@ import {
 import { logger } from "../../utils/logger.js";
 import { generateOnceNative } from "../../utils/nativeSingleShot.js";
 import type { LanguageModelMiddleware } from "../../types/index.js";
+
+/**
+ * Filter each contiguous run of text parts as one string.
+ *
+ * A prohibited term that straddles two adjacent text parts is invisible to a
+ * per-part filter, and the parts are concatenated downstream (`lifecycle.ts`
+ * joins adjacent text), so the term reached the caller whole. Anthropic's
+ * native path emits one text part per content block, so adjacent parts are a
+ * real shape, not a theoretical one. Non-text parts keep their position; a run
+ * is rebuilt as a single text part only when the filter changed it.
+ */
+const filterTextRuns = (
+  content: ReadonlyArray<LanguageModelV3Content>,
+  badWords: BadWordsConfig | undefined,
+  context: string,
+): LanguageModelV3Content[] => {
+  const out: LanguageModelV3Content[] = [];
+  let run: Array<Extract<LanguageModelV3Content, { type: "text" }>> = [];
+  const flushRun = (): void => {
+    if (run.length === 0) {
+      return;
+    }
+    const merged = run.map((part) => part.text).join("");
+    const filtered = applyContentFiltering(merged, badWords, context);
+    if (filtered.hasChanges) {
+      out.push({ ...run[0], text: filtered.filteredText });
+    } else {
+      out.push(...run);
+    }
+    run = [];
+  };
+  for (const part of content) {
+    if (part.type === "text") {
+      run.push(part);
+    } else {
+      flushRun();
+      out.push(part);
+    }
+  }
+  flushRun();
+  return out;
+};
 
 /**
  * Create Guardrails AI middleware for content filtering and policy enforcement
@@ -90,18 +134,7 @@ export function createGuardrailsMiddleware(
 
       result = {
         ...result,
-        content: result.content.map((part) =>
-          part.type === "text"
-            ? {
-                ...part,
-                text: applyContentFiltering(
-                  part.text,
-                  config.badWords,
-                  "generate",
-                ).filteredText,
-              }
-            : part,
-        ),
+        content: filterTextRuns(result.content, config.badWords, "generate"),
       };
 
       if (config.modelFilter?.enabled && config.modelFilter.filterModel) {
@@ -163,29 +196,52 @@ export function createGuardrailsMiddleware(
       const { stream, ...rest } = await doStream();
       let hasYieldedChunks = false;
 
+      // With bad-word filtering on, a text run is buffered and filtered as one
+      // string: a term split across deltas is invisible per delta and every
+      // consumer reassembles it. The run is released when a non-text part
+      // arrives or the stream ends, so the guardrail trades incremental
+      // delivery of that run for not being bypassable by chunking. With
+      // filtering off, deltas pass through untouched and unbuffered.
+      const bufferTextRuns = config.badWords?.enabled === true;
+      let pendingText:
+        | Extract<LanguageModelV3StreamPart, { type: "text-delta" }>
+        | undefined;
+      const releaseText = (
+        controller: TransformStreamDefaultController<LanguageModelV3StreamPart>,
+      ): void => {
+        if (!pendingText) {
+          return;
+        }
+        const filtered = applyContentFiltering(
+          pendingText.delta,
+          config.badWords,
+          "stream",
+        );
+        controller.enqueue(
+          filtered.hasChanges
+            ? { ...pendingText, delta: filtered.filteredText }
+            : pendingText,
+        );
+        pendingText = undefined;
+      };
+
       const transformStream = new TransformStream<
         LanguageModelV3StreamPart,
         LanguageModelV3StreamPart
       >({
         transform(chunk, controller) {
           hasYieldedChunks = true;
-          let filteredChunk = chunk;
-          if (filteredChunk.type === "text-delta") {
-            const filterResult = applyContentFiltering(
-              filteredChunk.delta,
-              config.badWords,
-              "stream",
-            );
-            if (filterResult.hasChanges) {
-              filteredChunk = {
-                ...filteredChunk,
-                delta: filterResult.filteredText,
-              };
-            }
+          if (chunk.type === "text-delta" && bufferTextRuns) {
+            pendingText = pendingText
+              ? { ...pendingText, delta: pendingText.delta + chunk.delta }
+              : chunk;
+            return;
           }
-          controller.enqueue(filteredChunk);
+          releaseText(controller);
+          controller.enqueue(chunk);
         },
-        flush() {
+        flush(controller) {
+          releaseText(controller);
           if (!hasYieldedChunks) {
             logger.warn(
               `[GuardrailsMiddleware] Stream ended without yielding any chunks`,

--- a/src/lib/types/middleware.ts
+++ b/src/lib/types/middleware.ts
@@ -21,6 +21,7 @@ export type {
   LanguageModelV3Message,
   LanguageModelV3Prompt,
   LanguageModelV3StreamPart,
+  LanguageModelV3Content,
   LanguageModelV3ToolCall,
   LanguageModelV3ToolChoice,
   LanguageModelV3Source,

--- a/test/continuous-test-suite-stream-middleware.ts
+++ b/test/continuous-test-suite-stream-middleware.ts
@@ -11,7 +11,7 @@ import "dotenv/config";
  */
 
 import assert from "node:assert/strict";
-import { createServer } from "node:http";
+import { createServer, type IncomingMessage, type Server } from "node:http";
 import { once } from "node:events";
 import { z } from "zod";
 import type {
@@ -835,6 +835,300 @@ await test("generate schema recovery still works with middleware enabled", async
     );
   } finally {
     await sdk.shutdown();
+    await server.close();
+  }
+});
+
+/**
+ * A prohibited term split across a boundary. The bad-word filter used to run
+ * on each text part (generate) and each text-delta (stream) in isolation, so a
+ * term that straddled two of them passed unchanged and was reassembled
+ * downstream — `lifecycle.ts` concatenates adjacent text parts, and every
+ * stream consumer concatenates deltas. Each case first proves the split reaches
+ * the consumer whole when no guardrail is configured, so a pass cannot come
+ * from the pieces never having been split, and only then asserts the guardrail
+ * catches the reassembled term.
+ */
+const SPLIT_TERM = ["inappro", "priate"] as const;
+const WHOLE_TERM = SPLIT_TERM.join("");
+
+const splitTermGuardrails = {
+  middlewareConfig: {
+    guardrails: {
+      enabled: true,
+      config: {
+        badWords: {
+          enabled: true,
+          list: [WHOLE_TERM],
+          replacementText: "CLEAN",
+        },
+      },
+    },
+  },
+};
+
+type SplitServer = {
+  baseURL: string;
+  requests: () => number;
+  close: () => Promise<void>;
+};
+
+const readRequestBody = (req: IncomingMessage): Promise<string> =>
+  new Promise((resolve) => {
+    let raw = "";
+    req.setEncoding("utf8");
+    req.on("data", (chunk: string) => {
+      raw += chunk;
+    });
+    req.on("end", () => resolve(raw));
+  });
+
+const listen = async (
+  server: Server,
+): Promise<{ port: number; close: () => Promise<void> }> => {
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  return {
+    port: typeof address === "object" && address ? address.port : 0,
+    close: () => new Promise((resolve) => server.close(() => resolve())),
+  };
+};
+
+/** OpenAI-compatible server that streams each piece as its own SSE chunk. */
+const startSplitDeltaChatServer = async (
+  pieces: ReadonlyArray<string>,
+): Promise<SplitServer> => {
+  let requests = 0;
+  const chunk = (delta: Record<string, unknown>, finish: string | null) =>
+    `data: ${JSON.stringify({
+      id: "split",
+      object: "chat.completion.chunk",
+      created: 1,
+      model: "gpt-4o-mini",
+      choices: [{ index: 0, delta, finish_reason: finish }],
+    })}\n\n`;
+  const server = createServer(async (req, res) => {
+    await readRequestBody(req);
+    requests += 1;
+    res.writeHead(200, {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    });
+    for (const piece of pieces) {
+      res.write(chunk({ role: "assistant", content: piece }, null));
+    }
+    res.write(chunk({}, "stop"));
+    res.write("data: [DONE]\n\n");
+    res.end();
+  });
+  const { port, close } = await listen(server);
+  return {
+    baseURL: `http://127.0.0.1:${port}/v1`,
+    requests: () => requests,
+    close,
+  };
+};
+
+/**
+ * Anthropic Messages server answering with one text block per piece — which
+ * the native Anthropic path turns into adjacent text parts in the V3 result.
+ * Serves both the JSON and the SSE form so whichever the generate path uses,
+ * the blocks stay split.
+ */
+const startSplitBlockAnthropicServer = async (
+  pieces: ReadonlyArray<string>,
+): Promise<SplitServer> => {
+  let requests = 0;
+  const model = "claude-sonnet-4-20250514";
+  const server = createServer(async (req, res) => {
+    const raw = await readRequestBody(req);
+    requests += 1;
+    const wantsStream = ((): boolean => {
+      try {
+        return (JSON.parse(raw) as { stream?: unknown }).stream === true;
+      } catch {
+        return false;
+      }
+    })();
+    if (!wantsStream) {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          id: "msg_split",
+          type: "message",
+          role: "assistant",
+          model,
+          content: pieces.map((text) => ({ type: "text", text })),
+          stop_reason: "end_turn",
+          stop_sequence: null,
+          usage: { input_tokens: 1, output_tokens: 2 },
+        }),
+      );
+      return;
+    }
+    res.writeHead(200, {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    });
+    const event = (type: string, data: Record<string, unknown>): void => {
+      res.write(
+        `event: ${type}\ndata: ${JSON.stringify({ type, ...data })}\n\n`,
+      );
+    };
+    event("message_start", {
+      message: {
+        id: "msg_split",
+        type: "message",
+        role: "assistant",
+        model,
+        content: [],
+        stop_reason: null,
+        usage: { input_tokens: 1, output_tokens: 0 },
+      },
+    });
+    pieces.forEach((text, index) => {
+      event("content_block_start", {
+        index,
+        content_block: { type: "text", text: "" },
+      });
+      event("content_block_delta", {
+        index,
+        delta: { type: "text_delta", text },
+      });
+      event("content_block_stop", { index });
+    });
+    event("message_delta", {
+      delta: { stop_reason: "end_turn", stop_sequence: null },
+      usage: { output_tokens: 2 },
+    });
+    event("message_stop", {});
+    res.end();
+  });
+  const { port, close } = await listen(server);
+  return {
+    baseURL: `http://127.0.0.1:${port}`,
+    requests: () => requests,
+    close,
+  };
+};
+
+const withEnv = async <T>(
+  vars: Record<string, string>,
+  fn: () => Promise<T>,
+): Promise<T> => {
+  const saved = new Map(
+    Object.keys(vars).map((key) => [key, process.env[key]] as const),
+  );
+  Object.assign(process.env, vars);
+  try {
+    return await fn();
+  } finally {
+    for (const [key, value] of saved) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+};
+
+await test("guardrail bad-word filtering catches a term split across stream deltas", async () => {
+  const server = await startSplitDeltaChatServer(SPLIT_TERM);
+  const sdk = new NeuroLink();
+  try {
+    const base = {
+      input: { text: "hello" },
+      provider: "openai",
+      model: "gpt-4o-mini",
+      disableTools: true,
+      disableInternalFallback: true,
+      credentials: {
+        openai: { apiKey: "sk-mock-local-server", baseURL: server.baseURL },
+      },
+    };
+    const unfiltered = await bounded(readText(await sdk.stream(base)));
+    assert.equal(
+      server.requests(),
+      1,
+      "precondition: split server not exercised",
+    );
+    assert.equal(
+      unfiltered,
+      WHOLE_TERM,
+      "precondition: split deltas did not reassemble into the whole term",
+    );
+    const filtered = await bounded(
+      readText(await sdk.stream({ ...base, middleware: splitTermGuardrails })),
+    );
+    assert.equal(
+      server.requests(),
+      2,
+      "guarded stream did not reach the provider",
+    );
+    assert.equal(
+      filtered,
+      "CLEAN",
+      "term split across stream deltas escaped the guardrail",
+    );
+  } finally {
+    await sdk.shutdown();
+    await server.close();
+  }
+});
+
+await test("guardrail bad-word filtering catches a term split across adjacent text parts (generate)", async () => {
+  const server = await startSplitBlockAnthropicServer(SPLIT_TERM);
+  try {
+    await withEnv(
+      {
+        ANTHROPIC_BASE_URL: server.baseURL,
+        ANTHROPIC_API_KEY: "sk-ant-mock-local-server",
+      },
+      async () => {
+        const sdk = new NeuroLink();
+        try {
+          const base = {
+            input: { text: "hello" },
+            provider: "anthropic",
+            model: "claude-sonnet-4-20250514",
+            disableTools: true,
+            disableInternalFallback: true,
+          };
+          const unfiltered = await sdk.generate(base);
+          assert.equal(
+            server.requests(),
+            1,
+            "precondition: split server not exercised",
+          );
+          assert.equal(
+            unfiltered.content,
+            WHOLE_TERM,
+            "precondition: adjacent text blocks did not reassemble into the whole term",
+          );
+          const filtered = await sdk.generate({
+            ...base,
+            middleware: splitTermGuardrails,
+          });
+          assert.equal(
+            server.requests(),
+            2,
+            "guarded generate did not reach the provider",
+          );
+          assert.equal(
+            filtered.content,
+            "CLEAN",
+            "term split across adjacent text parts escaped the guardrail",
+          );
+        } finally {
+          await sdk.shutdown();
+        }
+      },
+    );
+  } finally {
     await server.close();
   }
 });


### PR DESCRIPTION
## What

The built-in guardrails bad-word filter ran on each V3 text part in `wrapGenerate` and on each `text-delta` in `wrapStream`, in isolation. A prohibited term split across a boundary — `inappro` + `priate` — was invisible to both, and both boundaries are reassembled downstream: `lifecycle.ts` concatenates adjacent text parts, and every stream consumer concatenates deltas. The term reached the caller whole.

Both were flagged by CodeRabbit on the merged head of #1636 (`guardrails.ts:93` and `:181`). Neither is theoretical:

- **Generate.** Anthropic's native path emits one text part per content block, so adjacent text parts arrive whenever a reply has two text blocks.
- **Stream.** A token boundary can fall anywhere inside a word, so a per-delta filter could be defeated by chunking alone. This half is the filter's original design; #1636 made it reachable.

## How

- `filterTextRuns` filters each contiguous run of text parts as one string, keeps non-text parts in place, and rebuilds a run as a single text part only when the filter changed it.
- `wrapStream` buffers a text run while bad-word filtering is **enabled** and releases it, filtered once, when a non-text part arrives or the stream ends. That trades incremental delivery of the run for a guardrail that chunking cannot bypass. With filtering off, deltas pass through untouched and unbuffered, exactly as before.
- `LanguageModelV3Content` is now re-exported alongside `LanguageModelV3StreamPart` so the helper can type against the barrel (rule 13).

## Proof (red first)

Two cases in `test/continuous-test-suite-stream-middleware.ts`, each asserting its **precondition before its claim**: without guardrails the two pieces reassemble into the whole term at the consumer (so a pass cannot come from the pieces never having been split); with guardrails the consumer sees the replacement.

| case | drives | fixture | unfixed | fixed |
| --- | --- | --- | --- | --- |
| split across stream deltas | `stream()` → OpenAI-compatible path | local server emitting the term as two SSE deltas | ✗ | ✓ |
| split across adjacent text parts | `generate()` → native Anthropic path | local Messages server answering with two text blocks | ✗ | ✓ |

RED on the unfixed build: 20 passed, exactly these 2 failed. GREEN: 22/22 (the 20 existing cases plus these 2), with typecheck, build, lint and the test typecheck clean; `docs/api` regenerated with the prettier pass CI applies (44 anchor shifts in `middleware.ts` pages plus the new `LanguageModelV3Content` page).

## Trade-off worth knowing

With bad-word filtering enabled on a stream, the consumer receives each text run when it completes rather than delta by delta. A bounded look-behind (hold back only the longest configured word) would restore incremental delivery for plain word lists but cannot be made correct for `regexPatterns`, so this PR takes the simple, correct behaviour and leaves that optimisation as a follow-up if latency under filtering matters to anyone.
