### PR TITLE
fix(providers): replace NVIDIA NIM's decommissioned default model

### DIFF
--- a/docs/api/classes/ProviderRegistry.md
+++ b/docs/api/classes/ProviderRegistry.md
@@ -73,7 +73,7 @@ Register all providers with the factory
 
 > `static` **isRegistered**(): `boolean`
 
-Defined in: [factories/providerRegistry.ts:812](https://github.com/juspay/neurolink/blob/release/src/lib/factories/providerRegistry.ts#L812)
+Defined in: [factories/providerRegistry.ts:815](https://github.com/juspay/neurolink/blob/release/src/lib/factories/providerRegistry.ts#L815)
 
 Check if providers are registered
 
@@ -87,7 +87,7 @@ Check if providers are registered
 
 > `static` **clearRegistrations**(): `void`
 
-Defined in: [factories/providerRegistry.ts:819](https://github.com/juspay/neurolink/blob/release/src/lib/factories/providerRegistry.ts#L819)
+Defined in: [factories/providerRegistry.ts:822](https://github.com/juspay/neurolink/blob/release/src/lib/factories/providerRegistry.ts#L822)
 
 Clear registrations (for testing)
 
@@ -101,7 +101,7 @@ Clear registrations (for testing)
 
 > `static` **setOptions**(`options`): `void`
 
-Defined in: [factories/providerRegistry.ts:832](https://github.com/juspay/neurolink/blob/release/src/lib/factories/providerRegistry.ts#L832)
+Defined in: [factories/providerRegistry.ts:835](https://github.com/juspay/neurolink/blob/release/src/lib/factories/providerRegistry.ts#L835)
 
 Set registry options (should be called before initialization)
 
@@ -121,7 +121,7 @@ Set registry options (should be called before initialization)
 
 > `static` **getOptions**(): [`ProviderRegistryOptions`](../type-aliases/ProviderRegistryOptions.md)
 
-Defined in: [factories/providerRegistry.ts:840](https://github.com/juspay/neurolink/blob/release/src/lib/factories/providerRegistry.ts#L840)
+Defined in: [factories/providerRegistry.ts:843](https://github.com/juspay/neurolink/blob/release/src/lib/factories/providerRegistry.ts#L843)
 
 Get current registry options
 

--- a/docs/api/functions/calculateCost.md
+++ b/docs/api/functions/calculateCost.md
@@ -8,7 +8,7 @@
 
 > **calculateCost**(`provider`, `model`, `usage`): `number`
 
-Defined in: [utils/pricing.ts:951](https://github.com/juspay/neurolink/blob/release/src/lib/utils/pricing.ts#L951)
+Defined in: [utils/pricing.ts:959](https://github.com/juspay/neurolink/blob/release/src/lib/utils/pricing.ts#L959)
 
 Calculate the dollar cost of a generate/stream call based on token usage.
 Returns 0 if the provider/model combination is not in the pricing table.

--- a/docs/api/functions/hasPricing.md
+++ b/docs/api/functions/hasPricing.md
@@ -8,7 +8,7 @@
 
 > **hasPricing**(`provider`, `model`): `boolean`
 
-Defined in: [utils/pricing.ts:1006](https://github.com/juspay/neurolink/blob/release/src/lib/utils/pricing.ts#L1006)
+Defined in: [utils/pricing.ts:1014](https://github.com/juspay/neurolink/blob/release/src/lib/utils/pricing.ts#L1014)
 
 ## Parameters
 

--- a/src/lib/constants/contextWindows.ts
+++ b/src/lib/constants/contextWindows.ts
@@ -82,6 +82,7 @@ export const MODEL_CONTEXT_WINDOWS: Record<string, Record<string, number>> = {
     "mistralai/mixtral-8x7b-instruct-v0.1": 32_768,
     "microsoft/phi-4": 16_384,
     "google/gemma-3-27b-it": 8_192,
+    "openai/gpt-oss-20b": 131_072,
   },
   "lm-studio": {
     _default: 8_192,

--- a/src/lib/constants/enums.ts
+++ b/src/lib/constants/enums.ts
@@ -1028,6 +1028,13 @@ export enum DeepSeekModels {
  * Note: NIM hosts hundreds of models; pass arbitrary IDs via --model.
  */
 export enum NvidiaNimModels {
+  // NVIDIA retired a large part of this list upstream on 2026-08-26 —
+  // llama-3.3-70b, llama-3.1-70b, llama-3.2-90b-vision, the deepseek-r1
+  // distill and gemma-3-27b all answer "no longer available" now. The members
+  // are kept so existing callers still compile, but the provider default
+  // below must point at something live: gpt-oss-20b is on the current roster
+  // and was probed for text, streaming, tool calling and structured output.
+  GPT_OSS_20B = "openai/gpt-oss-20b",
   // Meta Llama
   LLAMA_3_3_70B_INSTRUCT = "meta/llama-3.3-70b-instruct",
   LLAMA_3_1_405B_INSTRUCT = "meta/llama-3.1-405b-instruct",

--- a/src/lib/factories/providerDescriptors.ts
+++ b/src/lib/factories/providerDescriptors.ts
@@ -349,7 +349,7 @@ const HAND_DESCRIPTORS: readonly ProviderDescriptor[] = [
       baseURL: "NVIDIA_NIM_BASE_URL",
       model: "NVIDIA_NIM_MODEL",
     },
-    defaultModel: NvidiaNimModels.LLAMA_3_3_70B_INSTRUCT,
+    defaultModel: NvidiaNimModels.GPT_OSS_20B,
     toolSupport: "native",
     localRuntime: false,
     healthCheck: "env-only",

--- a/src/lib/factories/providerRegistry.ts
+++ b/src/lib/factories/providerRegistry.ts
@@ -452,7 +452,10 @@ export class ProviderRegistry {
             await import("../providers/nvidiaNim/index.js");
           return new NvidiaNimProvider(modelName, sdk, undefined, nimCreds);
         },
-        process.env.NVIDIA_NIM_MODEL || NvidiaNimModels.LLAMA_3_3_70B_INSTRUCT,
+        process.env.NVIDIA_NIM_MODEL ||
+          PROVIDER_DESCRIPTORS_BY_NAME.get(AIProviderName.NVIDIA_NIM)
+            ?.defaultModel ||
+          NvidiaNimModels.GPT_OSS_20B,
         ["nvidia", "nim", "nvidia-nim"],
         PROVIDER_DESCRIPTORS_BY_NAME.get(AIProviderName.NVIDIA_NIM),
       );

--- a/src/lib/providers/nvidiaNim/client.ts
+++ b/src/lib/providers/nvidiaNim/client.ts
@@ -25,6 +25,7 @@ import {
   validateApiKey,
 } from "../../utils/providerConfig.js";
 import { OpenAIChatCompletionsProvider } from "../openaiChatCompletionsBase.js";
+import { PROVIDER_DESCRIPTORS_BY_NAME } from "../../factories/providerDescriptors.js";
 
 /**
  * Decide whether a NIM 400 response body is a rejection of the named
@@ -178,9 +179,18 @@ const getNimApiKey = (): string => {
 };
 
 const getDefaultNimModel = (): string => {
+  // NVIDIA retired meta/llama-3.3-70b-instruct upstream on 2026-08-26, so this
+  // fallback answered "no longer available" for anyone who selected nvidia-nim
+  // without naming a model. gpt-oss-20b is on the current roster and was
+  // probed for text, streaming, tool calling and structured output.
+  // Read the descriptor rather than repeating the literal. Review on this PR
+  // pointed out the default lived in four places and that changing only some
+  // of them is a no-op — which happened twice while tracking this down. The
+  // descriptor is the Factory+Registry convention's source of truth.
   return getProviderModel(
     "NVIDIA_NIM_MODEL",
-    NvidiaNimModels.LLAMA_3_3_70B_INSTRUCT,
+    PROVIDER_DESCRIPTORS_BY_NAME.get("nvidia-nim" as AIProviderName)
+      ?.defaultModel ?? NvidiaNimModels.GPT_OSS_20B,
   );
 };
 

--- a/src/lib/utils/modelChoices.ts
+++ b/src/lib/utils/modelChoices.ts
@@ -462,7 +462,7 @@ export const DEFAULT_MODELS: Record<
   [AIProviderName.OPENROUTER]: OpenRouterModels.CLAUDE_SONNET_4_5,
   [AIProviderName.OPENAI_COMPATIBLE]: "gpt-4o",
   [AIProviderName.DEEPSEEK]: DeepSeekModels.DEEPSEEK_CHAT,
-  [AIProviderName.NVIDIA_NIM]: NvidiaNimModels.LLAMA_3_3_70B_INSTRUCT,
+  [AIProviderName.NVIDIA_NIM]: NvidiaNimModels.GPT_OSS_20B,
   // LM Studio + llama.cpp auto-discover their loaded model from /v1/models;
   // an empty default is the documented signal to use that path.
   [AIProviderName.LM_STUDIO]: "",

--- a/src/lib/utils/pricing.ts
+++ b/src/lib/utils/pricing.ts
@@ -535,6 +535,14 @@ const PRICING: Record<
     },
   },
   "nvidia-nim": {
+    // Source: NVIDIA build.nvidia.com listed rates for openai/gpt-oss-20b,
+    // read 2026-09-06. NIM prices and models both rot — this PR exists
+    // because the default model was decommissioned — so re-check against
+    // https://build.nvidia.com/openai/gpt-oss-20b rather than trusting this.
+    "openai/gpt-oss-20b": {
+      input: 0.05 / 1_000_000,
+      output: 0.2 / 1_000_000,
+    },
     "meta/llama-3.3-70b-instruct": {
       input: 0.4 / 1_000_000,
       output: 0.4 / 1_000_000,

--- a/test/continuous-test-suite-new-providers.ts
+++ b/test/continuous-test-suite-new-providers.ts
@@ -264,16 +264,16 @@ const PROVIDERS: readonly ProviderUnderTest[] = [
     name: "nvidia-nim",
     available: HAS_NIM,
     unavailableReason: "NVIDIA_NIM_API_KEY not set",
-    // DeepSeek-R1-Distill emits proper <think>...</think> reasoning markers
-    // (E1 thinking.high asserts on those). The full deepseek-ai/deepseek-r1
-    // route returned 404 on NIM as of 2026-05; the 70B-Llama distill is the
-    // stable replacement and still emits reasoning. Previous nemotron model
-    // returned content but no reasoning signal, causing E1 to skip.
-    reasoningModel: "deepseek-ai/deepseek-r1-distill-llama-70b",
-    visionModel: "meta/llama-3.2-90b-vision-instruct",
-    // Pin a tool-trained NIM model for B2 stream-with-tools (the previous
-    // default landed on a model that declined to call tools).
-    fastModel: "meta/llama-3.3-70b-instruct",
+    // All three pins here went dead upstream: the deepseek-r1 distill,
+    // llama-3.2-90b-vision and llama-3.3-70b all answer "not available" now.
+    // Most of NIM's published roster additionally 404s as "not found for
+    // account", so these are chosen from what this account can actually
+    // reach and each was probed live for the property the cases need:
+    // gpt-oss-20b returns reasoning_content (E1 thinking.high) and calls
+    // tools (B2 stream-with-tools); llama-3.2-11b is the vision route.
+    reasoningModel: "openai/gpt-oss-20b",
+    visionModel: "meta/llama-3.2-11b-vision-instruct",
+    fastModel: "openai/gpt-oss-20b",
   },
   {
     name: "lm-studio",
@@ -1411,7 +1411,10 @@ async function section9Errors(): Promise<void> {
           const res = await sdk.generate({
             input: { text: TINY_PROMPT },
             provider: "nvidia-nim",
-            model: "google/gemma-3-27b-it", // typically doesn't support reasoning_budget
+            // google/gemma-3-27b-it was retired upstream. This one is live on
+            // this account and, being non-reasoning, still does not take a
+            // reasoning budget — which is what the case needs to provoke.
+            model: "meta/llama-3.2-11b-vision-instruct",
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             thinkingConfig: { thinkingLevel: "high" } as any,
             abortSignal: signal,

--- a/test/helpers/providerMatrix.ts
+++ b/test/helpers/providerMatrix.ts
@@ -472,7 +472,12 @@ const PROVIDER_ROWS: Array<[string, ProviderEntry]> = [
     "nvidia-nim",
     {
       name: "nvidia-nim",
-      defaultModel: "meta/llama-3.1-8b-instruct",
+      // NVIDIA retired meta/llama-3.1-8b-instruct on 2026-08-26, which left
+      // four permanently-red matrix cells. Most of the published roster also
+      // 404s as "not found for account", so the replacement is one this
+      // account can actually reach, verified live for text, streaming, tool
+      // calling and structured output.
+      defaultModel: "openai/gpt-oss-20b",
       envVars: ["NVIDIA_NIM_API_KEY"],
       text: true,
       streaming: true,


### PR DESCRIPTION
## What

NVIDIA retired `meta/llama-3.3-70b-instruct` on 2026-08-26. It was this provider's default in **four** separate places, so selecting `nvidia-nim` without naming a model failed outright — on `generate()` and `stream()` alike:

```
[nvidia-nim] The model 'meta/llama-3.3-70b-instruct' has reached its end of
life on 2026-08-26T09:00:00Z and is no longer available.
```

## Why four edits

The default lives in `getDefaultNimModel()` (`nvidiaNim/client.ts`), `providerRegistry.ts`, `providerDescriptors.ts` and `modelChoices.ts`. Changing any one of them leaves the behaviour identical, which is exactly what happened twice while tracking this down.

## The replacement

`openai/gpt-oss-20b`. Most of NIM's published roster is not usable either — it answers `404 "not found for account"` — so the replacement was chosen from what an account can actually reach, and probed live for every property something in this repo depends on:

| property | result |
| --- | --- |
| plain text | ✓ |
| streaming (SSE) | ✓ |
| tool calling | ✓ returns `tool_calls` |
| structured output (`response_format`) | ✓ valid JSON |
| fits `maxTokens: 200` | ✓ `finish_reason: stop`, 49 completion tokens |

Retired enum members are kept so existing callers still compile.

## Test rot from the same decommission

Four matrix cells and three `new-providers` pins referenced models that no longer exist — `meta/llama-3.1-8b-instruct`, `deepseek-ai/deepseek-r1-distill-llama-70b`, `meta/llama-3.2-90b-vision-instruct`, `meta/llama-3.3-70b-instruct`. Each moves to a model that resolves and carries the property its case needs: `gpt-oss-20b` emits `reasoning_content` and calls tools; `llama-3.2-11b-vision-instruct` is the vision route.

## Proof

Run from an empty directory with `env -i`, no `.env`, and only an API key, so nothing local could supply the model:

| | generate | stream |
| --- | --- | --- |
| old default `meta/llama-3.3-70b-instruct` | end-of-life error | end-of-life error |
| new default (no model argument) | `"OK"` | `"OK"` |

`test:matrix --provider=nvidia-nim` goes from 4 red cells to **4/4**. `lint`, `check`, `check:dts`, `test:provider-structure`, `test:model-manifests`, `test:provider-descriptors` and `verify:provider-onboarding` all clean.

## Note for maintainers

This machine's `.env` sets `NVIDIA_NIM_MODEL=meta/llama-3.1-70b-instruct`, itself decommissioned. That is local config, not repo state, so it is untouched here — but it will keep local runs red until it is updated or removed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for NVIDIA NIM’s `openai/gpt-oss-20b` model, including context limits and pricing.
  - Updated NVIDIA NIM’s default model to `openai/gpt-oss-20b`.

- **Bug Fixes**
  - Replaced retired NVIDIA NIM model selections with currently available models for text, vision, streaming, tool calling, and structured output scenarios.

- **Documentation**
  - Updated API source references to reflect current code locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->