### PR TITLE
fix(browser): give the bundle a working EventEmitter and an honest doStream

### DIFF
--- a/scripts/build-browser.mjs
+++ b/scripts/build-browser.mjs
@@ -81,7 +81,25 @@ export const isAbsolute = () => false;
 export const sep = '/';
 export const posix = { normalize:(p)=>p, join:(...a)=>a.join('/'), resolve:(...a)=>a.join('/'), sep:'/' };
 export const normalize = (p) => p;
-export const EventEmitter = class { on(){return this} off(){return this} emit(){return this} once(){return this} removeListener(){return this} addListener(){return this} removeAllListeners(){return this} };
+export const EventEmitter = class EventEmitter {
+  constructor(){ this._ev = new Map(); }
+  _list(t){ let l = this._ev.get(t); if(!l){ l=[]; this._ev.set(t,l);} return l; }
+  on(t,f){ this._list(t).push(f); return this; }
+  addListener(t,f){ return this.on(t,f); }
+  prependListener(t,f){ this._list(t).unshift(f); return this; }
+  once(t,f){ const g=(...a)=>{ this.off(t,g); f(...a); }; g.listener=f; return this.on(t,g); }
+  prependOnceListener(t,f){ const g=(...a)=>{ this.off(t,g); f(...a); }; g.listener=f; return this.prependListener(t,g); }
+  off(t,f){ const l=this._ev.get(t); if(l){ const i=l.findIndex(x=>x===f||x.listener===f); if(i>=0) l.splice(i,1); } return this; }
+  removeListener(t,f){ return this.off(t,f); }
+  removeAllListeners(t){ if(t===undefined) this._ev.clear(); else this._ev.delete(t); return this; }
+  emit(t,...a){ const l=this._ev.get(t); if(!l||l.length===0){ if(t==="error"){ throw a[0] instanceof Error ? a[0] : new Error("Unhandled error."); } return false; } for(const f of [...l]) f.apply(this,a); return true; }
+  listenerCount(t){ return (this._ev.get(t)||[]).length; }
+  listeners(t){ return [...(this._ev.get(t)||[])]; }
+  rawListeners(t){ return this.listeners(t); }
+  eventNames(){ return [...this._ev.keys()]; }
+  setMaxListeners(){ return this; }
+  getMaxListeners(){ return 10; }
+};
 export const AsyncLocalStorage = class { getStore(){} run(s,fn,...a){return fn(...a)} enterWith(){} disable(){} };
 export const Readable = class { pipe(){return this} on(){return this} read(){return null} push(){} destroy(){} };
 export const Writable = class { write(){return true} end(){} on(){return this} destroy(){} };

--- a/src/lib/providers/anthropic/client.ts
+++ b/src/lib/providers/anthropic/client.ts
@@ -1634,7 +1634,10 @@ export class AnthropicProvider extends BaseProvider {
       },
       doStream: () => {
         throw new Error(
-          `${providerName}: doStream is not implemented on the delegating model — the streaming path uses executeStream directly.`,
+          `${providerName}: doStream is not implemented on the delegating model. ` +
+            `NeuroLink streams through executeStream, reached via NeuroLink.stream() — ` +
+            `use that (the browser bundle exports the NeuroLink class) rather than ` +
+            `calling doStream on a model handle.`,
         );
       },
     };

--- a/src/lib/providers/openaiChatCompletionsBase.ts
+++ b/src/lib/providers/openaiChatCompletionsBase.ts
@@ -1060,7 +1060,10 @@ export abstract class OpenAIChatCompletionsProvider extends BaseProvider {
       },
       doStream: () => {
         throw new Error(
-          `${providerName}: doStream is not implemented on the delegating model — the streaming path uses executeStream directly.`,
+          `${providerName}: doStream is not implemented on the delegating model. ` +
+            `NeuroLink streams through executeStream, reached via NeuroLink.stream() — ` +
+            `use that (the browser bundle exports the NeuroLink class) rather than ` +
+            `calling doStream on a model handle.`,
         );
       },
     };

--- a/test/continuous-test-suite-browser-bundle.ts
+++ b/test/continuous-test-suite-browser-bundle.ts
@@ -21,6 +21,8 @@ import "dotenv/config";
  */
 
 import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import type { NeuroLink } from "../dist/index.js";
 import { defineSuite, runCommand } from "./helpers/harness.js";
 import {
@@ -30,6 +32,19 @@ import {
 import { assertDistFresh } from "./helpers/distFreshness.js";
 
 assertDistFresh();
+
+// assertDistFresh only proves dist/index.js is present and newer than src/.
+// This suite's whole subject is the browser artifact, which build:browser
+// emits separately — so say precisely which build is missing.
+const bundlePath = fileURLToPath(
+  new URL("../dist/browser/neurolink.min.js", import.meta.url),
+);
+if (!existsSync(bundlePath)) {
+  throw new Error(
+    "dist/browser/neurolink.min.js is missing — this suite tests the browser " +
+      "bundle specifically. Run `pnpm run build` first (it runs build:browser).",
+  );
+}
 
 const { test, runSuite } = defineSuite("Browser bundle", { offline: true });
 
@@ -197,6 +212,74 @@ await test("browser artifact supplies callback timers when Node immediates are a
     console.error(result.stderr);
   }
   assert.equal(result.exitCode, 0, "browser timer fixture failed");
+});
+
+await test("importing the bundle and exiting leaves no uncaught error", async () => {
+  const { spawn } = await import("node:child_process");
+  const script = `await import(${JSON.stringify(bundleURL.href)}); console.log("ok");`;
+  const child = spawn(process.execPath, ["--input-type=module", "-e", script], {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let stdout = "";
+  let stderr = "";
+  child.stdout.on("data", (d: Buffer) => (stdout += d.toString()));
+  child.stderr.on("data", (d: Buffer) => (stderr += d.toString()));
+  // Bounded: this case is about teardown, so a bundle that keeps the child
+  // alive must fail readably rather than hang until the runner kills it.
+  const code: number = await new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      resolve(-2);
+    }, 30_000);
+    child.on("close", (c) => {
+      clearTimeout(timer);
+      resolve(c ?? -1);
+    });
+  });
+  assert.notEqual(code, -2, "the child never exited — the bundle held it open");
+  assert.ok(stdout.includes("ok"), "precondition: the bundle never imported");
+  assert.equal(
+    /TypeError|is not a function/.test(stderr),
+    false,
+    "the bundle raised a TypeError on the way out",
+  );
+  assert.equal(code, 0, "importing the bundle and exiting did not exit 0");
+});
+
+/**
+ * `doStream` on a factory handle is advertised as a function but cannot
+ * stream: the delegating model it forwards to implements generation only, and
+ * NeuroLink's own streaming runs through `executeStream`. The old assertion
+ * checked `typeof doStream === "function"` and so passed over this entirely.
+ * Pin the real behaviour instead — including that the message names the
+ * supported path — so the limitation cannot be mistaken for a capability.
+ */
+await test("a factory handle's doStream fails with an actionable message", async () => {
+  const make = bundle.createOpenAI as Factory;
+  const model = make({ apiKey: "sk-not-used" })("gpt-4o-mini");
+  assert.equal(
+    typeof model.doStream,
+    "function",
+    "precondition: doStream is not even advertised",
+  );
+  let message = "";
+  try {
+    await (model.doStream as (o: unknown) => Promise<unknown>)({ prompt: [] });
+    assert.fail("doStream resolved; it cannot stream and must say so");
+  } catch (error) {
+    message = error instanceof Error ? error.message : String(error);
+  }
+  // `includes("NeuroLink")` was too weak: it passed while the message was a
+  // malformed multi-line template literal whose text contained a stray quote,
+  // a `+` and the source indentation. Pin the exact string.
+  assert.equal(
+    message,
+    "openai: doStream is not implemented on the delegating model. " +
+      "NeuroLink streams through executeStream, reached via NeuroLink.stream() — " +
+      "use that (the browser bundle exports the NeuroLink class) rather than " +
+      "calling doStream on a model handle.",
+    "doStream's failure message is not the intended one",
+  );
 });
 
 await runSuite();


### PR DESCRIPTION
## What

Importing `dist/browser/neurolink.min.js` and letting the process exit raised an **uncaught TypeError** — no NeuroLink instance, no API call, just an import:

```
TypeError: this.removeAllListeners is not a function
    at ToolDiscoveryService.destroy
    at ExternalServerManager.shutdown
```

The browser build stubs Node's `events`, and the stub declared six methods: `on`, `off`, `emit`, `once`, `removeListener`, `addListener`. Everything else was `undefined`.

## The bigger half of the same bug

The stub's `emit` was `emit(){return this}` — a **no-op**. Three classes in this bundle extend `EventEmitter` (`ToolDiscoveryService`, `ExternalServerManager`, `MCPCircuitBreaker`), so every event they raised went nowhere. Nothing could observe it: the methods were all present and all returned `this`, so the shape looked right and the behaviour was absent.

The stub is now a real `EventEmitter` — listener storage, `once`/`prepend` semantics, `removeAllListeners`, the `error`-with-no-listener throw, `listenerCount`, `eventNames`.

### The default export stays `{}` on purpose

One stub module backs *every* Node builtin here. Exporting `EventEmitter` as the default made `import process from "process"` resolve to a class, `process.platform` undefined, and module init fail across the bundle:

```
[NeuroLink:browser] module init skipped: TypeError: Cannot read properties of undefined (reading 'platform')
```

The new import-and-exit test caught that regression immediately, which is a fair advertisement for it.

## doStream: made honest, not made to work

A factory handle's `doStream` forwards to the internal delegating model, which implements generation only — NeuroLink streams through `executeStream`. Routing a V3 prompt through the public stream API instead is not viable: `StreamOptions` has no `messages` field, so multi-turn and multimodal prompts would be **silently flattened**. A lossy stream is worse than an honest failure, so the message now names the supported path (`NeuroLink.stream()`, and the bundle exports `NeuroLink`).

Real streaming from a bare model handle needs `doStream` implemented on the delegating model itself, reusing the body-building and SSE parsing already in `doGenerate`. That is its own change and is not attempted here.

## Proof (red first)

The suite asserted `typeof doStream === "function"` and so passed over every one of these. Two new cases, both failing on the unfixed bundle:

| case | unfixed | fixed |
| --- | --- | --- |
| importing the bundle and exiting leaves no uncaught error | ✗ | ✓ |
| a factory handle's `doStream` fails with an actionable message | ✗ | ✓ |

The first spawns a child process — the only way to observe a crash that happens *after* every other assertion in the file has already passed. Suite goes 5/5 → **7/7**.

A third case I wrote and removed: it imported `events` in the child and so exercised Node's real EventEmitter, not the bundle's stub. It passed before the fix, proving nothing. Deleted rather than kept.

Gates: `check` 0, `lint` 0, `check:dts` 0, `test:vendor-recovery` 0, `test:stream-middleware` 0, `test:anthropic-loop-characterization` 0, `test:providers-mocked` 0, `docs/api` drift 0.
