### PR TITLE
test(suites): close the review follow-ups left on #1643 and #1644

### DIFF
--- a/test/continuous-test-suite-media-gen.ts
+++ b/test/continuous-test-suite-media-gen.ts
@@ -1261,7 +1261,10 @@ async function testImageLRUCacheEviction(): Promise<boolean | null> {
         },
         provider: "vertex",
         model: "gemini-2.5-flash",
-        maxTokens: 50,
+        // 200, not 50: gemini-2.5-flash spends its budget on hidden
+        // reasoning first, so a 50-token cap returns empty visible text and
+        // this cell reports a harness defect as a product failure.
+        maxTokens: 200,
       });
       results.push(!!(result?.content && result.content.length > 0));
       if (i < 2) {
@@ -1314,7 +1317,8 @@ async function testImageRetryLogic(): Promise<boolean | null> {
       input: { text: "Describe the color blue in one sentence." },
       provider: "vertex",
       model: "gemini-2.5-flash",
-      maxTokens: 50,
+      // 200 for the same reason as the cache-eviction cell above.
+      maxTokens: 200,
     });
 
     if (!result?.content || result.content.length === 0) {
@@ -1512,8 +1516,10 @@ async function testVideoGenerationVertexAI(): Promise<boolean | null> {
 import { NeuroLink } from '${process.cwd()}/dist/index.js';
 
 // No freshness check here: this script runs from a temp directory with no
-// ./helpers to import it from, and the parent suite already ran
-// assertDistFresh() against the same dist before writing this file.
+// ./helpers to import it from. Note the parent suite does NOT run
+// assertDistFresh() either — the runner only checks that dist/index.js
+// exists, not that it is newer than src/. So this suite has no staleness
+// protection at all; the import below just needs dist to be present.
 
 async function testVideoGenerationVertexAI() {
   console.log('Testing video generation via Vertex AI generate()...');

--- a/test/continuous-test-suite-middleware.ts
+++ b/test/continuous-test-suite-middleware.ts
@@ -56,8 +56,13 @@ function logTest(
 // in CI (vertex) instead of one that requires a local daemon (ollama),
 // so the suite returns real PASS rather than blanket SKIPs.
 //
-// `thinkingLevel: "minimal"` keeps Gemini 2.5+ from spending its 50-token
-// budget on hidden reasoning and returning empty visible text. Combined
+// `thinkingLevel: "minimal"` reduces how much of the budget Gemini 2.5+
+// spends on hidden reasoning, but is not sufficient on its own: at
+// maxTokens 50 a probe measured 28 of 29 output tokens going to reasoning
+// anyway. The four cases that assert on generated content therefore ask
+// for 200. The rest of the file is deliberately smaller — the two
+// invalid-provider negative cases use 10 (they assert on the error, and
+// never reach a model) and the onChunk streaming case uses 100. Combined
 // with `disableTools: true` we keep the request shape pure-text so the
 // model isn't tempted to multi-step into a tool call (e.g. calculateMath
 // for "what is 2+2?") and exhaust the tiny token budget on tool plumbing

--- a/test/continuous-test-suite-native-vendor-recovery.ts
+++ b/test/continuous-test-suite-native-vendor-recovery.ts
@@ -233,6 +233,7 @@ await test("a silently ignored response_format falls back to the schema in the s
 });
 
 await test("a native tool round trip populates result.toolCalls", async () => {
+  let executions = 0;
   // `EnhancedGenerateResult.toolCalls` is a public field. The native loop
   // recorded the execution (toolExecutions, toolsUsed) but never mapped it
   // back onto toolCalls, so a caller reading the field the type promises saw
@@ -262,14 +263,34 @@ await test("a native tool round trip populates result.toolCalls", async () => {
         lookup: tool({
           description: "Looks a value up",
           inputSchema: z.object({ value: z.number() }),
-          execute: async () => ({ answer: 42 }),
+          execute: async () => {
+            executions += 1;
+            return { answer: 42 };
+          },
         }),
       },
     });
+    // A request count alone proves nothing: the server answers a second time
+    // for any second request, whether or not the tool ran or its result was
+    // submitted. Assert the execution itself and the tool result on the wire.
+    if (executions !== 1) {
+      throw new Error(
+        `precondition failed: the tool executed ${executions} times, expected 1`,
+      );
+    }
     if (server.requestCount() < 2) {
       throw new Error(
         "precondition failed: the tool round trip never happened",
       );
+    }
+    const followUp = JSON.parse(server.getAllRequestBodies()[1] ?? "{}") as {
+      messages?: Array<{ role?: string; tool_call_id?: string }>;
+    };
+    const toolResult = (followUp.messages ?? []).find(
+      (m) => m.role === "tool" && m.tool_call_id === "call_7",
+    );
+    if (!toolResult) {
+      throw new Error("the follow-up request carried no result for call_7");
     }
     const calls = result.toolCalls ?? [];
     if (calls.length !== 1) {


### PR DESCRIPTION
## What

Four review findings raised on [#1643](https://github.com/juspay/neurolink/pull/1643) and [#1644](https://github.com/juspay/neurolink/pull/1644) after they merged, none acted on at the time. All four verified against current code before fixing.

## From #1643 — a test that proved less than it looked

The `toolCalls` case established "a native tool round trip happened" with `server.requestCount() >= 2`. That proves nothing: the scripted server answers a second time for *any* second request, whether or not the tool ran or its result was submitted.

It now:
- counts executions inside the tool's own `execute` and asserts exactly **one**
- parses the follow-up request and asserts it carries a `tool` message with `tool_call_id === "call_7"`

Both are structural facts a request count cannot see. `test:vendor-recovery` stays 4/4.

## From #1644 — three loose ends

**A stale comment that also overstated a setting.** The middleware suite's `TEST_CONFIG` header still described a 50-token budget after that PR moved every call in the file to 200 — and credited `thinkingLevel: "minimal"` with preventing the empty-reply problem. #1644's own probe showed **28 of 29** output tokens going to hidden reasoning at 50 tokens *despite* that setting. The comment now says what the probe found.

**A comment asserting something false.** The media-gen child-script comment claimed the parent suite "already ran `assertDistFresh()` against the same dist". It does not — the suite has no freshness import at all, and the runner only checks that `dist/index.js` *exists*, not that it is newer than `src/`. The comment now states the real position: this suite has no staleness protection.

**Three cells #1644 did not reach.** The same file still had `provider: vertex`, `model: gemini-2.5-flash`, `maxTokens: 50` in the LRU-cache-eviction and retry-logic cases — both of which FAIL on empty content. That is precisely the harness-caused pattern #1644 identified, so they move to 200 for the same reason.

## Gates

`check` 0 · `lint` 0 · `check:test-parse` 0 · `build` 0 · `test:vendor-recovery` 4/4.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of image, video, middleware, and native tool integration tests.
  * Updated test configurations to accommodate provider-specific response lengths and reasoning behavior.
  * Strengthened validation that native tools execute exactly once and that their results are correctly submitted.
  * Clarified test coverage expectations for generated assets and streaming responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->