### PR TITLE
fix(core): take the Zod 4 native path only for Zod 4 schemas

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -367,6 +367,12 @@ export default [
         "error",
         {
           allow: [
+            // Which of convertZodToJsonSchema's two branches ran is visible
+            // only as a logger warning; the schema both branches return is
+            // valid, so a live generate() call cannot tell them apart. The
+            // regression also needs a Zod 3 shaped schema, and this repo
+            // installs only Zod 4.
+            "test/continuous-test-suite-zod3-schema-native-path.ts",
             // Chunk boundaries and reranker ordering are exact outcomes;
             // generate({ rag }) only ever shows the model's answer.
             "test/continuous-test-suite-rag.ts",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "test:openai-compat-streaming-retry": "pnpm exec tsx test/continuous-test-suite-openai-compat-streaming-retry.ts",
     "test:anthropic-streaming-retry": "pnpm exec tsx test/continuous-test-suite-anthropic-streaming-retry.ts",
     "test:adjust-body-after-400": "pnpm exec tsx test/continuous-test-suite-adjust-body-after-400.ts",
+    "test:zod3-schema-native-path": "pnpm exec tsx test/continuous-test-suite-zod3-schema-native-path.ts",
     "test:error-classification-e2e": "pnpm exec tsx test/continuous-test-suite-error-classification-e2e.ts",
     "test:error-classifier-contract": "pnpm exec tsx test/continuous-test-suite-error-classifier-contract.ts",
     "test:bedrock-inference-profile": "pnpm exec tsx test/continuous-test-suite-bedrock-inference-profile.ts",

--- a/src/lib/utils/schemaConversion.ts
+++ b/src/lib/utils/schemaConversion.ts
@@ -481,7 +481,7 @@ export function convertZodToJsonSchema(
   // Translate our `target` to Zod 4's native dialect identifier so the
   // openApi3 path emits the OpenAPI 3 schema shape Vertex/Gemini expect
   // (and not the default draft-07 anyOf/null union).
-  if (zodToJsonSchemaV4) {
+  if (zodToJsonSchemaV4 && isZod4Schema(zodSchema)) {
     const nativeTarget: Zod4NativeTarget =
       target === "openApi3" ? "openapi-3.0" : "draft-07";
     try {
@@ -763,6 +763,18 @@ export function isZodSchema(value: unknown): boolean {
     "_def" in value &&
     typeof (value as Record<string, unknown>).parse === "function"
   );
+}
+
+/**
+ * Whether a schema was built by Zod 4 specifically.
+ *
+ * Zod 4 hangs its internals off `_zod` (and `z.toJSONSchema` reads
+ * `schema._zod.def`); Zod 3 has only `_def`. The two can coexist in one install
+ * — a host on Zod 3 still resolves NeuroLink's own Zod 4 — so the presence of
+ * `z.toJSONSchema` says nothing about the schema actually being handed to it.
+ */
+export function isZod4Schema(value: unknown): boolean {
+  return !!(value && typeof value === "object" && "_zod" in value);
 }
 
 /**

--- a/test/continuous-test-suite-zod3-schema-native-path.ts
+++ b/test/continuous-test-suite-zod3-schema-native-path.ts
@@ -1,0 +1,162 @@
+#!/usr/bin/env tsx
+import "dotenv/config";
+
+/**
+ * Continuous Test Suite — the Zod 4 native path must key off the SCHEMA,
+ * not off `z.toJSONSchema` merely being importable.
+ *
+ * `convertZodToJsonSchema` preferred Zod 4's native `z.toJSONSchema` whenever
+ * that function existed:
+ *
+ *     if (zodToJsonSchemaV4) { ... }
+ *
+ * The two Zod majors coexist in real installs. A host application on Zod 3
+ * (very common — `@anthropic-ai/claude-agent-sdk` pins Zod 3) still resolves
+ * NeuroLink's own Zod 4, so `zodToJsonSchemaV4` is defined while every schema
+ * handed in was built by the host's Zod 3. Zod 4's converter reads
+ * `schema._zod.def`; a Zod 3 schema has only `_def`, so the call threw
+ *
+ *     TypeError: Cannot read properties of undefined (reading 'def')
+ *
+ * on EVERY tool-schema conversion, logged a warning, and fell through to the
+ * Zod 3 path. Observed 240 times in a single Curator run — correct output,
+ * but a thrown exception plus a warning per tool per request.
+ *
+ * The guard is now `zodToJsonSchemaV4 && isZod4Schema(zodSchema)`, so a Zod 3
+ * schema goes straight to the `zod-to-json-schema` path with no throw.
+ *
+ * No API keys and no second Zod install: the branch is decided purely by the
+ * schema's shape, so a Zod-3-shaped schema (`_def` + `parse`, no `_zod`)
+ * exercises exactly the code path a real Zod 3 schema takes.
+ *
+ * Run: npx tsx test/continuous-test-suite-zod3-schema-native-path.ts
+ */
+
+import { z } from "zod";
+import { defineSuite, assert, assertEqual } from "./helpers/harness.js";
+import {
+  convertZodToJsonSchema,
+  isZod4Schema,
+  isZodSchema,
+} from "../src/lib/utils/schemaConversion.js";
+import { logger } from "../src/lib/utils/logger.js";
+
+/**
+ * Run `fn` with `logger.warn` captured. The native attempt is only observable
+ * through the warning it logs on failure, so a test that merely checks the
+ * returned schema cannot tell the two branches apart — both produce one.
+ */
+function captureWarnings<T>(fn: () => T): { result: T; warnings: string[] } {
+  const warnings: string[] = [];
+  const original = logger.warn;
+  (logger as { warn: (...args: unknown[]) => void }).warn = (
+    ...args: unknown[]
+  ) => {
+    warnings.push(String(args[0]));
+  };
+  try {
+    return { result: fn(), warnings };
+  } finally {
+    (logger as { warn: unknown }).warn = original;
+  }
+}
+
+const NATIVE_FAILURE_WARNING = "Native z.toJSONSchema failed";
+
+/**
+ * A schema with Zod 3's shape: `_def` and `parse`, and crucially no `_zod`.
+ * Zod 3's real objects are structurally this from the guard's point of view.
+ */
+function zod3ShapedSchema(): Record<string, unknown> {
+  return {
+    _def: {
+      typeName: "ZodObject",
+      shape: () => ({}),
+    },
+    parse: (v: unknown) => v,
+  };
+}
+
+const { test, runSuite } = defineSuite("zod3 schema native path", {
+  offline: true,
+});
+
+void runSuite(async () => {
+  await test("isZod4Schema separates a real Zod 4 schema from a Zod 3 shaped one", () => {
+    const v4 = z.object({ a: z.string() });
+    assertEqual(isZod4Schema(v4), true, "a real Zod 4 schema carries _zod");
+    assertEqual(
+      isZod4Schema(zod3ShapedSchema()),
+      false,
+      "a Zod 3 schema has _def but no _zod",
+    );
+    assertEqual(
+      isZodSchema(zod3ShapedSchema()),
+      true,
+      "the Zod 3 shape is still recognised as a Zod schema at all",
+    );
+    assertEqual(isZod4Schema(null), false, "null is not a Zod 4 schema");
+    assertEqual(isZod4Schema("nope"), false, "a string is not a Zod 4 schema");
+  });
+
+  await test("a Zod 3 schema never attempts the Zod 4 native path", () => {
+    // Before the fix this threw inside z.toJSONSchema, was caught, logged
+    // "Native z.toJSONSchema failed", and only then produced a result. Both
+    // branches return a valid schema, so the WARNING is the only thing that
+    // distinguishes them — assert on that, or this test cannot fail.
+    const { result, warnings } = captureWarnings(() =>
+      convertZodToJsonSchema(zod3ShapedSchema()),
+    );
+    const out = result as Record<string, unknown>;
+    assert(!!out && typeof out === "object", "conversion returns an object");
+    assertEqual(out.type, "object", "a Zod 3 object schema stays an object");
+    assertEqual(
+      warnings.filter((w) => w.includes(NATIVE_FAILURE_WARNING)).length,
+      0,
+      `the Zod 4 native path must not be attempted for a Zod 3 schema — got: ${warnings.join(" | ")}`,
+    );
+  });
+
+  await test("real Zod 4 schemas still take the native path and keep their fields", () => {
+    const schema = z.object({
+      name: z.string().describe("the caller's name"),
+      count: z.number(),
+    });
+    const { result, warnings } = captureWarnings(() =>
+      convertZodToJsonSchema(schema),
+    );
+    assertEqual(
+      warnings.filter((w) => w.includes(NATIVE_FAILURE_WARNING)).length,
+      0,
+      "a genuine Zod 4 schema must convert natively without falling back",
+    );
+    const out = result as Record<string, unknown>;
+    assertEqual(
+      out.type,
+      "object",
+      "Zod 4 object converts to an object schema",
+    );
+    const props = out.properties as Record<string, { type?: string }>;
+    assert(!!props, "converted schema exposes properties");
+    assertEqual(props.name?.type, "string", "string field survives conversion");
+    assertEqual(
+      props.count?.type,
+      "number",
+      "number field survives conversion",
+    );
+    assert(
+      !("$schema" in out),
+      "$schema metadata is stripped for Vertex/Gemini",
+    );
+  });
+
+  await test("the openApi3 target still resolves for Zod 4 schemas", () => {
+    const out = convertZodToJsonSchema(
+      z.object({ id: z.string() }),
+      "openApi3",
+    ) as Record<string, unknown>;
+    assertEqual(out.type, "object", "openApi3 target yields an object schema");
+    const props = out.properties as Record<string, { type?: string }>;
+    assertEqual(props.id?.type, "string", "openApi3 keeps the field type");
+  });
+});


### PR DESCRIPTION
## The bug

`convertZodToJsonSchema` preferred Zod 4's native `z.toJSONSchema` whenever that function was importable:

```ts
if (zodToJsonSchemaV4) { ... }
```

That checks the **function**, not the **schema**. The two Zod majors coexist in real installs: a host application on Zod 3 still resolves NeuroLink's own Zod 4, so `zodToJsonSchemaV4` is defined while every schema handed in was built by the host's Zod 3.

Zod 4's converter reads `schema._zod.def`; a Zod 3 schema has only `_def`. So the call threw

```
TypeError: Cannot read properties of undefined (reading 'def')
```

on **every** tool-schema conversion — caught, warned, and fallen through to the Zod 3 path.

## Impact

Output was always correct, so this was invisible in behaviour. But a host on Zod 3 paid a thrown exception plus a `Native z.toJSONSchema failed` warning **per tool, per request**.

Found while upgrading Curator to 12.12.8: **240 occurrences in a single run**. Curator resolves `zod@3.25.76` because `@anthropic-ai/claude-agent-sdk` pins Zod 3, while NeuroLink 12.12.8 declares `zod ^4.3.6` — so both are installed and this fires constantly. Any host with the Agent SDK is in the same position.

Reproduction:

```js
const z3 = require("zod");            // 3.25.76
const v4 = require("zod/v4");         // present in 3.25.x, and NeuroLink's own zod@4
v4.toJSONSchema(z3.object({ a: z3.string() }));
// TypeError: Cannot read properties of undefined (reading 'def')
```

## The fix

Gate on the schema shape as well as the function:

```ts
if (zodToJsonSchemaV4 && isZod4Schema(zodSchema)) { ... }
```

`isZod4Schema()` keys off `_zod`, which only Zod 4 sets. Zod 3 schemas now go straight to the `zod-to-json-schema` path with no throw and no warning. Zod 4 schemas are unaffected.

## Test

`test/continuous-test-suite-zod3-schema-native-path.ts` (`pnpm test:zod3-schema-native-path`), offline, no API keys.

It asserts on the **warning**, not the returned schema. That distinction matters: both branches return a valid schema, so my first version of this test passed with the defect still planted. Verified by planting it:

- guard reverted to `if (zodToJsonSchemaV4)` → **exit 1**, `a Zod 3 schema never attempts the Zod 4 native path` fails
- guard restored → **exit 0**, 4/4 pass

The suite is on Rule 15's `allow` list: which branch ran is observable only through the logger, a live `generate()` cannot distinguish them, and this repo installs only Zod 4 so the Zod 3 side needs a shaped schema. The reason is stated in the file header, as the rule requires.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved schema conversion compatibility for Zod 3 schemas.
  - Zod 3 schemas now use the appropriate fallback conversion path instead of being incorrectly processed as Zod 4 schemas.
  - Zod 4 schemas continue to support native conversion, including OpenAPI 3 targets.
  - Prevented unnecessary conversion warnings for supported schema versions.

- **Tests**
  - Added coverage for Zod 3 and Zod 4 schema detection and conversion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->