### PR TITLE
test(json-e2e): repoint the groq cell off a decommissioned model

### DIFF
--- a/test/continuous-test-suite-json-e2e.ts
+++ b/test/continuous-test-suite-json-e2e.ts
@@ -314,7 +314,11 @@ const CELLS: Cell[] = [
   { provider: "xai", model: "grok-3", tier: "breadth", strictSchema: false },
   {
     provider: "groq",
-    model: "llama-3.3-70b-versatile",
+    // llama-3.3-70b-versatile was decommissioned upstream — it now answers
+    // "does not exist or you do not have access to it", so this cell could
+    // only ever fail. gpt-oss-120b is groq's catalog default and was probed
+    // live for text and tool calling.
+    model: "openai/gpt-oss-120b",
     tier: "breadth",
     strictSchema: false,
   },


### PR DESCRIPTION
## What

groq retired `llama-3.3-70b-versatile`. Verified live:

```
The model `llama-3.3-70b-versatile` does not exist or you do not have access to it.
```

The `json-e2e` groq cell pins that model, so it could only ever fail — and `json-e2e` is in no CI job, which is why nothing reported it.

`openai/gpt-oss-120b` replaces it: groq's own catalog default, probed live for text and for tool calling (`finish_reason: tool_calls`) before being used here.

## Why only one line

The retired id appears seven times. Six are deliberate or inert, and each was checked rather than assumed:

| site | why it stays |
| --- | --- |
| `providers-mocked.ts:2746` | declares it as `const deadModel` **on purpose**, to drive the invalid-model fallback path |
| `error-classification-e2e.ts:759` | scripts a 404 `model_decommissioned` and asserts `InvalidModelError` — it *wants* a retired model |
| `error-classification-e2e.ts:520` | fake credential + mock base URL; the model string is only a label |
| `openai-compat-catalog.ts:227` | asserts on the request URL/headers a mock captured; nothing leaves the process |
| `provider-wiring.ts:444` | a frozen enum-value map whose own comment says to fix the codegen, never the literal |
| `enums.ts` + `groq.json` | kept for backward compatibility — same treatment the NVIDIA decommission got in #1650 |

## Not the same shape as the NVIDIA one

#1650 was user-facing: nvidia-nim's *shipped default* was decommissioned, in four places. Here groq's shipped default is already `openai/gpt-oss-120b` and is live, so **no user is affected** — this is test rot only.

## Gates

`check` 0 · `lint` 0 · `check:test-parse` 0.

## Credit

The decommission was spotted by the session working on tier-2 structured output while investigating an unrelated symptom.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the continuous test suite to use Groq’s current default model.
  * Verified support for both text generation and tool calling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->