### PR TITLE
fix(file-detector): fetch URL inputs once

### DIFF
--- a/src/lib/utils/fileDetector.ts
+++ b/src/lib/utils/fileDetector.ts
@@ -352,7 +352,34 @@ export class FileDetector {
         },
       },
       async (span) => {
-        const detection = await FileDetector.detect(input, options);
+        // A URL used to be detected before it was loaded: MimeTypeStrategy
+        // issued a HEAD for Content-Type, then loadFromURL issued a GET for
+        // the body. Fetch it once and reuse the GET headers for the MIME
+        // strategy. A caller's explicit mimetypeHint remains authoritative,
+        // while a server header still comes after magic bytes.
+        const isUrlInput =
+          typeof input === "string" &&
+          (input.startsWith("http://") || input.startsWith("https://"));
+        const loadedUrl = isUrlInput
+          ? await FileDetector.loadUrl(input, options)
+          : undefined;
+        const detection = loadedUrl
+          ? {
+              ...(await FileDetector.detect(
+                loadedUrl.content,
+                {
+                  ...options,
+                  filenameHint:
+                    options?.filenameHint ||
+                    FileDetector.deriveInputFilename(input),
+                },
+                loadedUrl.contentType,
+                options?.filenameHint ||
+                  FileDetector.deriveInputFilename(input),
+              )),
+              source: "url" as const,
+            }
+          : await FileDetector.detect(input, options);
 
         span.setAttribute(ATTR.FILE_CATEGORY, detection.type);
         span.setAttribute(ATTR.FILE_MIMETYPE, detection.mimeType || "unknown");
@@ -367,11 +394,9 @@ export class FileDetector {
           options?.allowedTypes &&
           !options.allowedTypes.includes(detection.type)
         ) {
-          const content = await FileDetector.loadContent(
-            input,
-            detection,
-            options,
-          );
+          const content =
+            loadedUrl?.content ??
+            (await FileDetector.loadContent(input, detection, options));
           const errors: string[] = [];
 
           for (const allowedType of options.allowedTypes) {
@@ -432,11 +457,9 @@ export class FileDetector {
           return result;
         }
 
-        const content = await FileDetector.loadContent(
-          input,
-          detection,
-          options,
-        );
+        const content =
+          loadedUrl?.content ??
+          (await FileDetector.loadContent(input, detection, options));
         const csvOptions: CSVProcessorOptions | undefined = options?.csvOptions;
         const result = await FileDetector.processFile(
           content,
@@ -828,6 +851,8 @@ export class FileDetector {
   private static async detect(
     input: FileInput,
     options?: FileDetectorOptions,
+    responseMimeType?: string,
+    extensionInput?: string,
   ): Promise<FileDetectionResult> {
     // Short-circuit on a trustworthy caller-provided mimetype hint. This is
     // the eager-path counterpart to FileReferenceRegistry.register()'s hint
@@ -861,14 +886,18 @@ export class FileDetector {
     const confidenceThreshold = options?.confidenceThreshold ?? 80;
     const strategies: DetectionStrategy[] = [
       new MagicBytesStrategy(),
-      new MimeTypeStrategy(),
+      new MimeTypeStrategy(responseMimeType),
       new ExtensionStrategy(),
       new ContentHeuristicStrategy(),
     ];
 
     let best: FileDetectionResult | null = null;
     for (const strategy of strategies) {
-      const result = await strategy.detect(input);
+      const result = await strategy.detect(
+        strategy instanceof ExtensionStrategy && extensionInput
+          ? extensionInput
+          : input,
+      );
       if (!best || result.metadata.confidence > best.metadata.confidence) {
         best = result;
       }
@@ -2017,58 +2046,18 @@ export class FileDetector {
     url: string,
     options?: FileDetectorOptions,
   ): Promise<Buffer> {
+    return (await FileDetector.loadUrl(url, options)).content;
+  }
+
+  /**
+   * Fetch a URL once and retain its response MIME type for detection.
+   */
+  private static async loadUrl(
+    url: string,
+    options?: FileDetectorOptions,
+  ): Promise<{ content: Buffer; contentType: string }> {
     const maxSize = options?.maxSize || 200 * 1024 * 1024; // 200MB default (matches Curator memory-safety cap)
     const timeout = options?.timeout || FileDetector.DEFAULT_NETWORK_TIMEOUT;
-
-    // #317: pre-flight HEAD to reject an oversized file BEFORE downloading any
-    // body. content-length is advisory (chunked responses omit it), so a
-    // missing/invalid header — or a server that refuses HEAD — falls through to
-    // the streaming byte guard below; only a genuine oversize rejection stops
-    // the GET from ever running.
-    //
-    // #323: skip the pre-flight entirely when this exact URL was recently seen
-    // (its Content-Type is still cached, whether from a prior loadFromURL GET
-    // or a MimeTypeStrategy HEAD) — issuing a fresh HEAD here would defeat the
-    // whole point of that cache. The streaming byte guard in the GET below
-    // still enforces maxSize even without a pre-flight, so this doesn't remove
-    // the oversize protection — it only skips the redundant round-trip for a
-    // URL we've already been talking to within the last 60s.
-    if (getCachedUrlContentType(url, Date.now()) === undefined) {
-      try {
-        const head = await request(url, {
-          dispatcher: redirectFollowingDispatcher(5),
-          method: "HEAD",
-          headersTimeout: FileDetector.DEFAULT_HEAD_TIMEOUT,
-          bodyTimeout: FileDetector.DEFAULT_HEAD_TIMEOUT,
-        });
-        // Drain/close the (empty) HEAD body so the connection can be reused.
-        await head.body.dump();
-        // Only trust `content-length` on a genuine 2xx response. A non-2xx
-        // HEAD (redirect the dispatcher didn't follow, 403/404/405 "HEAD not
-        // allowed", 5xx, …) can still carry a stale/irrelevant
-        // `content-length` header — enforcing size off of that would reject
-        // (or silently pass) based on the wrong body. Treat any non-2xx HEAD
-        // as if the header were missing and fall through to the streaming
-        // GET guard below, which enforces maxSize independently either way.
-        if (head.statusCode >= 200 && head.statusCode < 300) {
-          const declaredLength = Number(head.headers["content-length"]);
-          if (Number.isFinite(declaredLength) && declaredLength > maxSize) {
-            throw new Error(
-              `File too large: ${formatFileSize(declaredLength)} (max: ${formatFileSize(maxSize)})`,
-            );
-          }
-        }
-      } catch (error) {
-        if (error instanceof Error && /File too large/.test(error.message)) {
-          throw error;
-        }
-        logger.debug(
-          `[FileDetector] HEAD pre-flight skipped for ${redactUrlForError(url)}: ${
-            sanitizeErrorCause(error).message
-          }`,
-        );
-      }
-    }
 
     return withRetry(
       async () => {
@@ -2088,13 +2077,25 @@ export class FileDetector {
             );
           }
 
+          const contentType =
+            (response.headers["content-type"] as string) || "";
+          const declaredLength = Number(response.headers["content-length"]);
+          if (Number.isFinite(declaredLength) && declaredLength > maxSize) {
+            // `request()` resolves after response headers arrive. Close the
+            // unread stream before throwing so a declared oversize response
+            // never enters the body-reading loop or holds its connection.
+            // Undici emits an abort error asynchronously when the stream is
+            // destroyed, so consume that expected event before closing it.
+            response.body.once("error", () => {});
+            response.body.destroy();
+            throw new Error(
+              `File too large: ${formatFileSize(declaredLength)} (max: ${formatFileSize(maxSize)})`,
+            );
+          }
+
           // #323: cache the Content-Type from this GET so a subsequent detection
           // of the same URL needs no HEAD.
-          setCachedUrlContentType(
-            url,
-            (response.headers["content-type"] as string) || "",
-            Date.now(),
-          );
+          setCachedUrlContentType(url, contentType, Date.now());
 
           const chunks: Buffer[] = [];
           let totalSize = 0;
@@ -2109,7 +2110,7 @@ export class FileDetector {
             chunks.push(chunk);
           }
 
-          return Buffer.concat(chunks);
+          return { content: Buffer.concat(chunks), contentType };
         } catch (error) {
           // Node/undici DNS, TLS, and connect-timeout errors embed the full
           // request URL (including a presigned query token) in
@@ -2912,7 +2913,21 @@ class MagicBytesStrategy implements DetectionStrategy {
  * Detects file type from HTTP Content-Type headers
  */
 class MimeTypeStrategy implements DetectionStrategy {
+  constructor(private readonly responseMimeType?: string) {}
+
   async detect(input: FileInput): Promise<FileDetectionResult> {
+    if (this.responseMimeType !== undefined) {
+      const contentType = this.responseMimeType;
+      const type = this.mimeToFileType(contentType);
+      return {
+        type,
+        mimeType: contentType.split(";")[0].trim(),
+        extension: null,
+        source: "url",
+        metadata: { confidence: type !== "unknown" ? 85 : 0 },
+      };
+    }
+
     if (typeof input !== "string" || !this.isURL(input)) {
       return this.unknown();
     }

--- a/test/continuous-test-suite-bugfixes.ts
+++ b/test/continuous-test-suite-bugfixes.ts
@@ -2321,22 +2321,26 @@ const tests: TestFunction[] = [
     },
   },
   {
-    name: "FileDetector #317: pre-flight HEAD rejects an oversized URL before the GET",
+    name: "FileDetector #317: GET headers reject an oversized URL without a HEAD",
     category: "pdf-processor",
     fn: async () => {
       let getCalled = false;
+      let headCalled = false;
       const server = http.createServer((req, res) => {
         if (req.method === "HEAD") {
-          res.setHeader(
-            "content-length",
-            req.url === "/big" ? String(500 * 1024 * 1024) : "12",
-          );
-          res.setHeader("content-type", "application/pdf");
+          headCalled = true;
           res.end();
         } else {
           getCalled = true;
+          const body = Buffer.from("%PDF-1.4\nok");
+          res.setHeader(
+            "content-length",
+            req.url === "/big"
+              ? String(500 * 1024 * 1024)
+              : String(body.length),
+          );
           res.setHeader("content-type", "application/pdf");
-          res.end("%PDF-1.4\nok");
+          res.end(body);
         }
       });
       await new Promise<void>((r) => server.listen(0, "127.0.0.1", () => r()));
@@ -2351,7 +2355,7 @@ const tests: TestFunction[] = [
           }
         ).loadFromURL.bind(FileDetector);
 
-        // Oversized: rejected via HEAD, GET never runs.
+        // Oversized: rejected from GET headers, without an extra HEAD.
         let rejected = false;
         try {
           await load(`http://127.0.0.1:${addr.port}/big`, {
@@ -2360,16 +2364,17 @@ const tests: TestFunction[] = [
         } catch (e) {
           rejected = e instanceof Error && /too large/i.test(e.message);
         }
-        if (!rejected || getCalled) {
+        if (!rejected || !getCalled || headCalled) {
           return false;
         }
 
-        // Normal: HEAD passes, GET proceeds.
+        // Normal: GET proceeds without a HEAD.
         getCalled = false;
+        headCalled = false;
         const buf = await load(`http://127.0.0.1:${addr.port}/ok`, {
           maxSize: 10 * 1024 * 1024,
         });
-        return getCalled && buf.length > 0;
+        return getCalled && !headCalled && buf.length > 0;
       } finally {
         await new Promise<void>((r) => server.close(() => r()));
       }
@@ -8284,6 +8289,141 @@ exit 127
       }
     },
   },
+  {
+    name: "FileDetector #323: fresh URLs use one GET, with magic bytes ahead of GET MIME",
+    category: "file-detector",
+    fn: async () => {
+      let headCount = 0;
+      let getCount = 0;
+      const png = Buffer.from(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+        "base64",
+      );
+      const server = http.createServer((req, res) => {
+        if (req.method === "HEAD") {
+          headCount++;
+          res.end();
+          return;
+        }
+        getCount++;
+        if (req.url === "/remote-file") {
+          // The response MIME is deliberately wrong: fetching before
+          // detection must still leave magic-byte detection in first place.
+          res.writeHead(200, { "content-type": "text/plain" });
+          res.end(png);
+          return;
+        }
+        if (req.url === "/report.csv") {
+          // A MIME-less CSV URL must still be classified from its filename.
+          res.end("name,value\n");
+          return;
+        }
+        // No extension or magic bytes: the MIME from this same GET is the
+        // next detection signal after magic bytes.
+        res.writeHead(200, { "content-type": "text/csv" });
+        res.end("name,value\none,1\n");
+      });
+      await new Promise<void>((resolve) =>
+        server.listen(0, "127.0.0.1", resolve),
+      );
+      try {
+        const address = server.address() as { port: number };
+        const magicResult = await FileDetector.detectAndProcess(
+          `http://127.0.0.1:${address.port}/remote-file`,
+        );
+        const mimeResult = await FileDetector.detectAndProcess(
+          `http://127.0.0.1:${address.port}/remote-data`,
+        );
+        const extensionResult = await FileDetector.detectAndProcess(
+          `http://127.0.0.1:${address.port}/report.csv`,
+        );
+        const detect = (
+          FileDetector as unknown as {
+            detect: (
+              input: Buffer,
+              options?: undefined,
+              responseMimeType?: string,
+              extensionInput?: string,
+            ) => Promise<{
+              type: string;
+              metadata: { confidence: number };
+            }>;
+          }
+        ).detect.bind(FileDetector);
+        const extensionDetection = await detect(
+          Buffer.from("name,value\\n"),
+          undefined,
+          "",
+          `http://127.0.0.1:${address.port}/report.csv`,
+        );
+        return (
+          magicResult.type === "image" &&
+          mimeResult.type === "csv" &&
+          extensionResult.type === "csv" &&
+          extensionDetection.type === "csv" &&
+          extensionDetection.metadata.confidence === 85 &&
+          getCount === 3 &&
+          headCount === 0
+        );
+      } finally {
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+      }
+    },
+  },
+  {
+    name: "FileDetector #323: declared oversize URL rejects before its GET body is read",
+    category: "file-detector",
+    fn: async () => {
+      let headCount = 0;
+      let getCount = 0;
+      let bodyWritten = false;
+      const server = http.createServer((req, res) => {
+        if (req.method === "HEAD") {
+          headCount++;
+          res.end();
+          return;
+        }
+        getCount++;
+        res.writeHead(200, {
+          "content-length": String(2048),
+          "content-type": "application/octet-stream",
+        });
+        res.flushHeaders();
+        const bodyTimer = setTimeout(() => {
+          bodyWritten = true;
+          res.end(Buffer.alloc(2048));
+        }, 100);
+        res.once("close", () => clearTimeout(bodyTimer));
+      });
+      await new Promise<void>((resolve) =>
+        server.listen(0, "127.0.0.1", resolve),
+      );
+      try {
+        const address = server.address() as { port: number };
+        const loadFromURL = (
+          FileDetector as unknown as {
+            loadFromURL: (
+              url: string,
+              options?: { maxSize?: number },
+            ) => Promise<Buffer>;
+          }
+        ).loadFromURL.bind(FileDetector);
+        let rejected = false;
+        try {
+          await loadFromURL(`http://127.0.0.1:${address.port}/oversize.bin`, {
+            maxSize: 1024,
+          });
+        } catch (error) {
+          rejected =
+            error instanceof Error && /File too large/.test(error.message);
+        }
+        await new Promise((resolve) => setTimeout(resolve, 150));
+        return rejected && getCount === 1 && headCount === 0 && !bodyWritten;
+      } finally {
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+      }
+    },
+  },
   // ---------- Round-4: CLI/processor decoupling + testable validators ----------
   {
     name: "CLI (review #1202 round 4): commandFactory.ts no longer imports processor sizeLimits (CLI/SDK layering)",
@@ -9155,11 +9295,11 @@ exit 127
         resetImageCache();
       }
 
-      // -- FileDetector: two URLs differing only by a secret query param
-      // must NOT share a urlContentTypeCache entry anymore (a fresh HEAD is
-      // expected for the second, different-secret URL), while the identical
-      // URL requested again must still avoid a redundant HEAD.
+      // -- FileDetector: every public URL load now uses its GET response for
+      // both bytes and detection. Different signed URLs remain independent,
+      // and no public path needs a HEAD.
       let headCount = 0;
+      let getCount = 0;
       const png = Buffer.from(
         "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
         "base64",
@@ -9170,6 +9310,7 @@ exit 127
           res.setHeader("content-type", "image/png");
           res.end();
         } else {
+          getCount++;
           res.setHeader("content-type", "image/png");
           res.end(png);
         }
@@ -9190,19 +9331,22 @@ exit 127
         ).loadFromURL.bind(FileDetector);
         await load(url1, { maxSize: 1024 });
 
-        // Different secret (SIGB), same path: must NOT reuse url1's cache
-        // entry — this is the collision the T4 fix closes.
+        // Different secret (SIGB), same path: it must be loaded independently.
         headCount = 0;
         const result2 = await FileDetector.detectAndProcess(url2);
-        if (!(result2.type === "image" && headCount > 0)) {
+        if (!(result2.type === "image" && getCount === 2 && headCount === 0)) {
           return false;
         }
 
-        // The exact same URL (SIGA) requested again must still hit the
-        // cache — proving the hash suffix is deterministic, not random.
+        // The exact same URL (SIGA) still requires only its single GET.
         headCount = 0;
+        const getCountBeforeRepeat = getCount;
         const result1Again = await FileDetector.detectAndProcess(url1);
-        return result1Again.type === "image" && headCount === 0;
+        return (
+          result1Again.type === "image" &&
+          getCount === getCountBeforeRepeat + 1 &&
+          headCount === 0
+        );
       } finally {
         await new Promise<void>((r) => server.close(() => r()));
       }


### PR DESCRIPTION
# Pull Request

## Description

Fetch URL inputs once and reuse the successful GET response's MIME type during file detection. This removes the initial HEAD request on the public URL path while keeping magic-byte detection ahead of the server MIME value.

Declared oversize responses are rejected from GET headers before the body-reading loop starts; the unread stream is closed before returning the size error.

## Related Issues

Fixes #323

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance improvement

## Changes Made

- Load URL inputs before detection and reuse the buffer throughout processing.
- Carry the GET `Content-Type` into the MIME strategy after magic-byte detection.
- Check a successful GET's declared length before reading its response body.
- Add request-count, MIME fallback, magic-byte priority, and declared-size regression coverage.

## Breaking Changes

- [x] No breaking changes

## New Provider Onboarding

- [x] N/A — no provider/model change

## Testing

- [x] Unit tests added/updated
- [x] Existing relevant test suite passes

Commands run:

```text
pnpm run test:bugfixes       # 283 passed
pnpm run check               # passed
pnpm run build               # passed
pnpm run lint                # passed with existing repository warnings only
```

The repository pre-push hook also passed `check:deps`, the build, `test:provider-structure` (3 passed), and `test:model-manifests` (14 passed).

## Code Quality

- [x] Code follows the project's style guidelines
- [x] Code is properly formatted
- [x] No console.log statements in production code
- [x] No hardcoded API keys or secrets
- [x] TypeScript strict mode compliance
- [x] Proper error handling implemented

## Documentation

- [x] JSDoc comments added/updated for the new internal result type

## Commit Message Format

- [x] Commit message follows format: `type(scope): description`
- [x] Valid type used: `fix`
- [x] Scope specified

## Dependencies

- [x] No dependency changes

## Performance Impact

- [x] Performance improved

For a fresh URL processed through `FileDetector.detectAndProcess`, the local regression server observes one GET and zero HEAD requests. The test also covers a misleading MIME header, so binary magic bytes remain the first detection signal.

## Security Considerations

- [x] No new security implications identified

The existing redirect dispatcher, request error redaction, retry wrapper, and streaming size guard remain in the request path.

## Deployment Notes

- [x] No special deployment steps

## Additional Notes

The implementation does not rely on the prior short-lived URL MIME cache to avoid the initial request. It uses the same GET response for both content and detection metadata.

---

## Pre-submission Checklist

- [x] Read and followed the Contributing Guidelines
- [x] Verified automated pre-commit checks pass
- [x] Built the project successfully
- [x] Ran validation checks
- [x] Ensured the commit message follows semantic format
- [x] Added regression coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection and processing of files loaded from URLs.
  - Oversized URL responses are now rejected earlier, helping prevent unnecessary downloads.
  - File types are identified more reliably using response metadata, file contents, and URL filenames.
  - URLs without MIME-type information can still be classified by their file extension.
  - Distinct signed URLs are handled independently, improving reliability when accessing dynamic links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->