### PR TITLE
fix(native-loop): surface vendor reasoning and cache the Anthropic tools block

### DIFF
--- a/docs/api/classes/NeuroLink.md
+++ b/docs/api/classes/NeuroLink.md
@@ -469,7 +469,7 @@ Gracefully shutdown NeuroLink and all MCP connections
 
 > **generateText**(`options`): `Promise`\<[`TextGenerationResult`](../type-aliases/TextGenerationResult.md)\>
 
-Defined in: [neurolink.ts:6508](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L6508)
+Defined in: [neurolink.ts:6507](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L6507)
 
 BACKWARD COMPATIBILITY: Legacy generateText method
 Internally calls generate() and converts result format
@@ -490,7 +490,7 @@ Internally calls generate() and converts result format
 
 > **streamText**(`prompt`, `options?`): `Promise`\<`AsyncIterable`\<`string`, `any`, `any`\>\>
 
-Defined in: [neurolink.ts:9005](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L9005)
+Defined in: [neurolink.ts:9004](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L9004)
 
 BACKWARD COMPATIBILITY: Legacy streamText method
 Internally calls stream() and converts result format
@@ -515,7 +515,7 @@ Internally calls stream() and converts result format
 
 > **stream**(`options`): `Promise`\<[`StreamResult`](../type-aliases/StreamResult.md)\>
 
-Defined in: [neurolink.ts:9088](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L9088)
+Defined in: [neurolink.ts:9087](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L9087)
 
 Stream AI-generated content in real-time using the best available provider.
 This method provides real-time streaming of AI responses with full MCP tool integration.
@@ -588,7 +588,7 @@ When conversation memory operations fail (if enabled)
 
 > **setToolRoutingServers**(`servers`): `void`
 
-Defined in: [neurolink.ts:9980](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L9980)
+Defined in: [neurolink.ts:9979](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L9979)
 
 Supplies (or replaces) the pre-call tool routing server catalog.
 
@@ -613,7 +613,7 @@ alone does not activate it.
 
 > **getKnowledgeStatus**(): [`KnowledgeEngineStatus`](../type-aliases/KnowledgeEngineStatus.md) \| `null`
 
-Defined in: [neurolink.ts:9998](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L9998)
+Defined in: [neurolink.ts:9997](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L9997)
 
 Knowledge-grounding engine health (null when it was not configured).
 
@@ -627,7 +627,7 @@ Knowledge-grounding engine health (null when it was not configured).
 
 > **getEventEmitter**(): `TypedEventEmitter`\<[`NeuroLinkEvents`](../type-aliases/NeuroLinkEvents.md)\>
 
-Defined in: [neurolink.ts:12413](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12413)
+Defined in: [neurolink.ts:12412](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12412)
 
 Get the EventEmitter instance to listen to NeuroLink events for real-time monitoring and debugging.
 This method provides access to the internal event system that emits events during AI generation,
@@ -833,7 +833,7 @@ This method does not throw errors as it returns the internal EventEmitter
 
 > **hasPendingHITLConfirmation**(`confirmationId`): `boolean`
 
-Defined in: [neurolink.ts:12453](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12453)
+Defined in: [neurolink.ts:12452](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12452)
 
 Whether a HITL confirmation is still awaiting a response on THIS instance.
 
@@ -888,7 +888,7 @@ neurolink.getEventEmitter().emit("hitl:confirmation-response", { ... });
 
 > **getToolDedupConfig**(): [`ToolDedupConfig`](../type-aliases/ToolDedupConfig.md) \| `undefined`
 
-Defined in: [neurolink.ts:12469](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12469)
+Defined in: [neurolink.ts:12468](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12468)
 
 Returns the instance-level tool-dedup configuration, or `undefined` when
 toolDedup was not provided at construction time.
@@ -911,7 +911,7 @@ parameter through the full call stack.
 
 > **getToolsConfig**(): [`ToolConfig`](../type-aliases/ToolConfig.md) \| `undefined`
 
-Defined in: [neurolink.ts:12480](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12480)
+Defined in: [neurolink.ts:12479](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12479)
 
 Returns the instance-level `tools` config (master switch, include/exclude
 lists, discovery mode), or `undefined` when not provided at construction.
@@ -929,7 +929,7 @@ instance policy with per-call options on every generate/stream call.
 
 > **getDiscoveryPins**(`sessionKey`): `ReadonlySet`\<`string`\>
 
-Defined in: [neurolink.ts:12491](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12491)
+Defined in: [neurolink.ts:12490](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12490)
 
 Tools discovered via `search_tools` for a session (`tools.discovery`
 mode). Pinned tools are sent in full on every subsequent call of that
@@ -953,7 +953,7 @@ are never the ones evicted at the session cap.
 
 > **pinDiscoveredTools**(`sessionKey`, `toolNames`): `void`
 
-Defined in: [neurolink.ts:12508](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12508)
+Defined in: [neurolink.ts:12507](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12507)
 
 Pin discovered tools to a session (called by the `search_tools`
 meta-tool on hydration). Append-only within a session; the map is
@@ -979,7 +979,7 @@ bounded by evicting the least-recently-used session past 1000 sessions.
 
 > **checkCredentials**(`input`): `Promise`\<\{ `provider`: `string`; `status`: `"network"` \| `"expired"` \| `"unknown"` \| `"ok"` \| `"missing"` \| `"denied"`; `detail`: `string`; \}\>
 
-Defined in: [neurolink.ts:12553](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12553)
+Defined in: [neurolink.ts:12552](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12552)
 
 Curator P1-1: synchronous credential health check for a single provider.
 
@@ -1031,7 +1031,7 @@ if (health.status !== "ok") {
 
 > **emitToolStart**(`toolName`, `input`, `startTime?`): `string`
 
-Defined in: [neurolink.ts:12632](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12632)
+Defined in: [neurolink.ts:12631](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12631)
 
 Emit tool start event with execution tracking
 
@@ -1067,7 +1067,7 @@ executionId for tracking this specific execution
 
 > **emitToolEnd**(`toolName`, `result?`, `error?`, `startTime?`, `endTime?`, `executionId?`): `void`
 
-Defined in: [neurolink.ts:12683](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12683)
+Defined in: [neurolink.ts:12682](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12682)
 
 Emit tool end event with execution summary
 
@@ -1119,7 +1119,7 @@ Optional execution ID for tracking
 
 > **getCurrentToolExecutions**(): [`ToolExecutionContext`](../type-aliases/ToolExecutionContext.md)[]
 
-Defined in: [neurolink.ts:12764](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12764)
+Defined in: [neurolink.ts:12763](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12763)
 
 Get current tool execution contexts for stream metadata
 
@@ -1133,7 +1133,7 @@ Get current tool execution contexts for stream metadata
 
 > **getToolExecutionHistory**(): [`ToolExecutionSummary`](../type-aliases/ToolExecutionSummary.md)[]
 
-Defined in: [neurolink.ts:12771](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12771)
+Defined in: [neurolink.ts:12770](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12770)
 
 Get tool execution history
 
@@ -1147,7 +1147,7 @@ Get tool execution history
 
 > **clearCurrentStreamExecutions**(): `void`
 
-Defined in: [neurolink.ts:12778](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12778)
+Defined in: [neurolink.ts:12777](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12777)
 
 Clear current stream tool executions (called at stream start)
 
@@ -1161,7 +1161,7 @@ Clear current stream tool executions (called at stream start)
 
 > **registerTool**(`name`, `tool`, `options?`): `void`
 
-Defined in: [neurolink.ts:12794](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12794)
+Defined in: [neurolink.ts:12793](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12793)
 
 Register a custom tool that will be available to all AI providers
 
@@ -1207,7 +1207,7 @@ Tool in MCPExecutableTool format (unified MCP protocol type)
 
 > **setToolContext**(`context`): `void`
 
-Defined in: [neurolink.ts:12945](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12945)
+Defined in: [neurolink.ts:12944](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12944)
 
 Set the context that will be passed to tools during execution
 This context will be merged with any runtime context passed by the AI model
@@ -1230,7 +1230,7 @@ Context object containing session info, tokens, shop data, etc.
 
 > **getToolContext**(): `Record`\<`string`, `unknown`\> \| `undefined`
 
-Defined in: [neurolink.ts:12960](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12960)
+Defined in: [neurolink.ts:12959](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12959)
 
 Get the current tool execution context
 
@@ -1246,7 +1246,7 @@ Current context or undefined if not set
 
 > **clearToolContext**(): `void`
 
-Defined in: [neurolink.ts:12969](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12969)
+Defined in: [neurolink.ts:12968](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12968)
 
 Clear the tool execution context
 
@@ -1260,7 +1260,7 @@ Clear the tool execution context
 
 > **registerTools**(`tools`): `void`
 
-Defined in: [neurolink.ts:12981](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12981)
+Defined in: [neurolink.ts:12980](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12980)
 
 Register multiple tools at once - Supports both object and array formats
 
@@ -1285,7 +1285,7 @@ Array format (Lighthouse compatible): [{ name: string, tool: MCPExecutableTool }
 
 > **unregisterTool**(`name`): `boolean`
 
-Defined in: [neurolink.ts:13004](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13004)
+Defined in: [neurolink.ts:13003](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13003)
 
 Unregister a custom tool
 
@@ -1309,7 +1309,7 @@ true if the tool was removed, false if it didn't exist
 
 > **useToolMiddleware**(`middleware`): `this`
 
-Defined in: [neurolink.ts:13023](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13023)
+Defined in: [neurolink.ts:13022](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13022)
 
 Register a global tool middleware that runs on every tool execution.
 Middleware receives the tool, params, context, and a next() function.
@@ -1334,7 +1334,7 @@ this (for chaining)
 
 > **getToolMiddlewares**(): [`ToolMiddleware`](../type-aliases/ToolMiddleware.md)[]
 
-Defined in: [neurolink.ts:13036](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13036)
+Defined in: [neurolink.ts:13035](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13035)
 
 Get all registered tool middlewares
 
@@ -1348,7 +1348,7 @@ Get all registered tool middlewares
 
 > **flushToolBatch**(): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:13043](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13043)
+Defined in: [neurolink.ts:13042](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13042)
 
 Flush any pending batched tool calls immediately
 
@@ -1362,7 +1362,7 @@ Flush any pending batched tool calls immediately
 
 > **getMCPEnhancementsConfig**(): [`MCPEnhancementsConfig`](../type-aliases/MCPEnhancementsConfig.md) \| `undefined`
 
-Defined in: [neurolink.ts:13052](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13052)
+Defined in: [neurolink.ts:13051](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13051)
 
 Get the current MCP enhancements configuration
 
@@ -1376,7 +1376,7 @@ Get the current MCP enhancements configuration
 
 > **updateAgenticLoopReport**(`sessionId`, `report`, `userId?`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:13075](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13075)
+Defined in: [neurolink.ts:13074](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13074)
 
 Update agentic loop report metadata for a conversation session.
 Upserts a report entry by reportId — updates existing or adds new.
@@ -1426,7 +1426,7 @@ await neurolink.updateAgenticLoopReport("session-123", {
 
 > **getCustomTools**(): `Map`\<`string`, \{ `name`: `string`; `description`: `string`; `inputSchema?`: `object`; `execute?`: (`params`, `context?`) => `unknown`; \}\>
 
-Defined in: [neurolink.ts:13111](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13111)
+Defined in: [neurolink.ts:13110](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13110)
 
 Get all registered custom tools
 
@@ -1442,7 +1442,7 @@ Map of tool names to MCPExecutableTool format
 
 > **addInMemoryMCPServer**(`serverId`, `serverInfo`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:13249](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13249)
+Defined in: [neurolink.ts:13248](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13248)
 
 Add an in-memory MCP server (from git diff)
 Allows registration of pre-instantiated server objects
@@ -1471,7 +1471,7 @@ Server configuration
 
 > **getInMemoryServers**(): `Map`\<`string`, [`MCPServerInfo`](../type-aliases/MCPServerInfo.md)\>
 
-Defined in: [neurolink.ts:13293](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13293)
+Defined in: [neurolink.ts:13292](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13292)
 
 Get all registered in-memory servers as a Map for ID-based lookup.
 
@@ -1494,7 +1494,7 @@ Map of server IDs to MCPServerInfo
 
 > **getInMemoryServerInfos**(): [`MCPServerInfo`](../type-aliases/MCPServerInfo.md)[]
 
-Defined in: [neurolink.ts:13320](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13320)
+Defined in: [neurolink.ts:13319](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13319)
 
 Get in-memory servers as an array of MCPServerInfo.
 
@@ -1524,7 +1524,7 @@ Array of MCPServerInfo for in-memory servers
 
 > **getAutoDiscoveredServerInfos**(): [`MCPServerInfo`](../type-aliases/MCPServerInfo.md)[]
 
-Defined in: [neurolink.ts:13336](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13336)
+Defined in: [neurolink.ts:13335](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13335)
 
 Get auto-discovered servers as MCPServerInfo - ZERO conversion needed
 
@@ -1540,7 +1540,7 @@ Array of MCPServerInfo
 
 > **executeTool**\<`T`\>(`toolName`, `params?`, `options?`): `Promise`\<`T`\>
 
-Defined in: [neurolink.ts:13348](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13348)
+Defined in: [neurolink.ts:13347](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13347)
 
 Execute a specific tool by name with robust error handling
 Supports both custom tools and MCP server tools with timeout, retry, and circuit breaker patterns
@@ -1631,7 +1631,7 @@ Tool execution result
 
 > **getAllAvailableTools**(): `Promise`\<[`ToolInfo`](../type-aliases/ToolInfo.md)[]\>
 
-Defined in: [neurolink.ts:14448](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14448)
+Defined in: [neurolink.ts:14447](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14447)
 
 ##### Returns
 
@@ -1643,7 +1643,7 @@ Defined in: [neurolink.ts:14448](https://github.com/juspay/neurolink/blob/releas
 
 > **getProviderStatus**(`options?`): `Promise`\<[`ProviderStatus`](../type-aliases/ProviderStatus.md)[]\>
 
-Defined in: [neurolink.ts:14630](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14630)
+Defined in: [neurolink.ts:14629](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14629)
 
 Get comprehensive status of all AI providers
 Primary method for provider health checking and diagnostics
@@ -1666,7 +1666,7 @@ Primary method for provider health checking and diagnostics
 
 > **testProvider**(`providerName`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:14811](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14811)
+Defined in: [neurolink.ts:14810](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14810)
 
 Test a specific AI provider's connectivity and authentication
 
@@ -1690,7 +1690,7 @@ Promise resolving to true if provider is working
 
 > **getBestProvider**(`requestedProvider?`): `Promise`\<`string`\>
 
-Defined in: [neurolink.ts:14843](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14843)
+Defined in: [neurolink.ts:14842](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14842)
 
 Get the best available AI provider based on configuration and availability
 
@@ -1714,7 +1714,7 @@ Promise resolving to the best provider name
 
 > **getAvailableProviders**(): `Promise`\<`string`[]\>
 
-Defined in: [neurolink.ts:14852](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14852)
+Defined in: [neurolink.ts:14851](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14851)
 
 Get list of all available AI provider names
 
@@ -1730,7 +1730,7 @@ Array of supported provider names
 
 > **isValidProvider**(`providerName`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:14862](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14862)
+Defined in: [neurolink.ts:14861](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14861)
 
 Validate if a provider name is supported
 
@@ -1754,7 +1754,7 @@ True if provider name is valid
 
 > **getMCPStatus**(): `Promise`\<[`MCPStatus`](../type-aliases/MCPStatus.md)\>
 
-Defined in: [neurolink.ts:14875](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14875)
+Defined in: [neurolink.ts:14874](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14874)
 
 Get comprehensive MCP (Model Context Protocol) status information
 
@@ -1770,7 +1770,7 @@ Promise resolving to MCP status details
 
 > **listMCPServers**(): `Promise`\<[`MCPServerInfo`](../type-aliases/MCPServerInfo.md)[]\>
 
-Defined in: [neurolink.ts:14945](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14945)
+Defined in: [neurolink.ts:14944](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14944)
 
 List all configured MCP servers with their status
 
@@ -1786,7 +1786,7 @@ Promise resolving to array of MCP server information
 
 > **testMCPServer**(`serverId`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:14960](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14960)
+Defined in: [neurolink.ts:14959](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14959)
 
 Test connectivity to a specific MCP server
 
@@ -1810,7 +1810,7 @@ Promise resolving to true if server is reachable
 
 > **hasProviderEnvVars**(`providerName`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:15001](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15001)
+Defined in: [neurolink.ts:15000](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15000)
 
 Check if a provider has the required environment variables configured
 
@@ -1834,7 +1834,7 @@ Promise resolving to true if provider has required env vars
 
 > **checkProviderHealth**(`providerName`, `options?`): `Promise`\<\{ `provider`: `string`; `isHealthy`: `boolean`; `isConfigured`: `boolean`; `hasApiKey`: `boolean`; `lastChecked`: `Date`; `error?`: `string`; `warning?`: `string`; `responseTime?`: `number`; `configurationIssues`: `string`[]; `recommendations`: `string`[]; \}\>
 
-Defined in: [neurolink.ts:15027](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15027)
+Defined in: [neurolink.ts:15026](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15026)
 
 Perform comprehensive health check on a specific provider
 
@@ -1878,7 +1878,7 @@ Promise resolving to detailed health status
 
 > **checkAllProvidersHealth**(`options?`): `Promise`\<`object`[]\>
 
-Defined in: [neurolink.ts:15073](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15073)
+Defined in: [neurolink.ts:15072](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15072)
 
 Check health of all supported providers
 
@@ -1916,7 +1916,7 @@ Promise resolving to array of health statuses for all providers
 
 > **getProviderHealthSummary**(): `Promise`\<\{ `total`: `number`; `healthy`: `number`; `configured`: `number`; `hasIssues`: `number`; `healthyProviders`: `string`[]; `unhealthyProviders`: `string`[]; `recommendations`: `string`[]; \}\>
 
-Defined in: [neurolink.ts:15117](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15117)
+Defined in: [neurolink.ts:15116](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15116)
 
 Get a summary of provider health across all supported providers
 
@@ -1932,7 +1932,7 @@ Promise resolving to health summary statistics
 
 > **clearProviderHealthCache**(`providerName?`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:15164](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15164)
+Defined in: [neurolink.ts:15163](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15163)
 
 Clear provider health cache (useful for re-testing after configuration changes)
 
@@ -1954,7 +1954,7 @@ Optional specific provider to clear cache for
 
 > **getToolExecutionMetrics**(): `Record`\<`string`, \{ `totalExecutions`: `number`; `successfulExecutions`: `number`; `failedExecutions`: `number`; `successRate`: `number`; `averageExecutionTime`: `number`; `lastExecutionTime`: `number`; `errorCategories`: `Record`\<`string`, `number`\>; \}\>
 
-Defined in: [neurolink.ts:15175](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15175)
+Defined in: [neurolink.ts:15174](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15174)
 
 Get execution metrics for all tools
 
@@ -1970,7 +1970,7 @@ Object with execution metrics for each tool
 
 > **setModelAliasConfig**(`config`): `void`
 
-Defined in: [neurolink.ts:15219](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15219)
+Defined in: [neurolink.ts:15218](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15218)
 
 NL-004: Set model alias/deprecation configuration.
 Models in the alias map will be warned, redirected, or blocked based on their action.
@@ -1993,7 +1993,7 @@ Model alias configuration with aliases map
 
 > **getToolCircuitBreakerStatus**(): `Record`\<`string`, \{ `state`: `"closed"` \| `"open"` \| `"half-open"`; `failureCount`: `number`; `isHealthy`: `boolean`; \}\>
 
-Defined in: [neurolink.ts:15232](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15232)
+Defined in: [neurolink.ts:15231](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15231)
 
 Get circuit breaker status for all tools
 
@@ -2009,7 +2009,7 @@ Object with circuit breaker status for each tool
 
 > **resetToolCircuitBreaker**(`toolName`): `void`
 
-Defined in: [neurolink.ts:15267](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15267)
+Defined in: [neurolink.ts:15266](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15266)
 
 Reset circuit breaker for a specific tool
 
@@ -2031,7 +2031,7 @@ Name of the tool to reset circuit breaker for
 
 > **clearToolExecutionMetrics**(): `void`
 
-Defined in: [neurolink.ts:15284](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15284)
+Defined in: [neurolink.ts:15283](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15283)
 
 Clear all tool execution metrics
 
@@ -2045,7 +2045,7 @@ Clear all tool execution metrics
 
 > **getToolHealthReport**(): `Promise`\<\{ `totalTools`: `number`; `healthyTools`: `number`; `unhealthyTools`: `number`; `tools`: `Record`\<`string`, \{ `name`: `string`; `isHealthy`: `boolean`; `metrics`: \{ `totalExecutions`: `number`; `successRate`: `number`; `averageExecutionTime`: `number`; `lastExecutionTime`: `number`; `errorCategories`: `Record`\<`string`, `number`\>; \}; `circuitBreaker`: \{ `state`: `"closed"` \| `"open"` \| `"half-open"`; `failureCount`: `number`; \}; `issues`: `string`[]; `recommendations`: `string`[]; \}\>; \}\>
 
-Defined in: [neurolink.ts:15293](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15293)
+Defined in: [neurolink.ts:15292](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15292)
 
 Get comprehensive tool health report
 
@@ -2061,7 +2061,7 @@ Detailed health report for all tools
 
 > **ensureConversationMemoryInitialized**(): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:15448](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15448)
+Defined in: [neurolink.ts:15447](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15447)
 
 Initialize conversation memory if enabled (public method for explicit initialization)
 This is useful for testing or when you want to ensure conversation memory is ready
@@ -2078,7 +2078,7 @@ Promise resolving to true if initialization was successful, false otherwise
 
 > **getConversationStats**(): `Promise`\<[`ConversationMemoryStats`](../type-aliases/ConversationMemoryStats.md)\>
 
-Defined in: [neurolink.ts:15468](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15468)
+Defined in: [neurolink.ts:15467](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15467)
 
 Get conversation memory statistics (public API)
 
@@ -2092,7 +2092,7 @@ Get conversation memory statistics (public API)
 
 > **getConversationHistory**(`sessionId`): `Promise`\<[`ChatMessage`](../type-aliases/ChatMessage.md)[]\>
 
-Defined in: [neurolink.ts:15495](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15495)
+Defined in: [neurolink.ts:15494](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15494)
 
 Get complete conversation history for a specific session (public API)
 
@@ -2116,7 +2116,7 @@ Array of ChatMessage objects in chronological order, or empty array if session d
 
 > **clearConversationSession**(`sessionId`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:15551](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15551)
+Defined in: [neurolink.ts:15550](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15550)
 
 Clear conversation history for a specific session (public API)
 
@@ -2136,7 +2136,7 @@ Clear conversation history for a specific session (public API)
 
 > **clearAllConversations**(): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:15577](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15577)
+Defined in: [neurolink.ts:15576](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15576)
 
 Clear all conversation history (public API)
 
@@ -2150,7 +2150,7 @@ Clear all conversation history (public API)
 
 > **listSessions**(`userId?`): `Promise`\<[`SessionListItem`](../type-aliases/SessionListItem.md)[]\>
 
-Defined in: [neurolink.ts:15605](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15605)
+Defined in: [neurolink.ts:15604](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15604)
 
 List all conversation sessions with metadata (public API)
 
@@ -2174,7 +2174,7 @@ Array of session list items with metadata
 
 > **exportSession**(`sessionId`, `options?`): `Promise`\<[`SessionExport`](../type-aliases/SessionExport.md) \| `null`\>
 
-Defined in: [neurolink.ts:15654](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15654)
+Defined in: [neurolink.ts:15653](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15653)
 
 Export a single session with full history and metadata (public API)
 
@@ -2210,7 +2210,7 @@ Session export object with full history
 
 > **exportAllSessions**(`userId?`, `options?`): `Promise`\<[`SessionExport`](../type-aliases/SessionExport.md)[]\>
 
-Defined in: [neurolink.ts:15739](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15739)
+Defined in: [neurolink.ts:15738](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15738)
 
 Export all sessions for a user (public API)
 
@@ -2246,7 +2246,7 @@ Array of session exports
 
 > **storeToolExecutions**(`sessionId`, `userId`, `toolCalls`, `toolResults`, `currentTime?`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:15803](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15803)
+Defined in: [neurolink.ts:15802](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15802)
 
 Store tool executions in conversation memory if enabled and Redis is configured
 
@@ -2294,7 +2294,7 @@ Promise resolving when storage is complete
 
 > **isToolExecutionStorageAvailable**(): `boolean`
 
-Defined in: [neurolink.ts:15873](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15873)
+Defined in: [neurolink.ts:15872](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15872)
 
 Check if tool execution storage is available.
 
@@ -2315,7 +2315,7 @@ whether the active memory backend can persist tool executions
 
 > **getSessionMessages**(`sessionId`, `userId?`): `Promise`\<[`ChatMessage`](../type-aliases/ChatMessage.md)[]\>
 
-Defined in: [neurolink.ts:15883](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15883)
+Defined in: [neurolink.ts:15882](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15882)
 
 Get the raw messages array for a session.
 Returns the full messages list without context filtering or summarization.
@@ -2344,7 +2344,7 @@ Array of ChatMessage objects, or empty array if session doesn't exist
 
 > **setSessionMessages**(`sessionId`, `messages`, `userId?`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:15924](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15924)
+Defined in: [neurolink.ts:15923](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15923)
 
 Replace the entire messages array for a session.
 
@@ -2378,7 +2378,7 @@ Optional user ID for scoped Redis key lookup
 
 > **modifyLastAssistantMessage**(`sessionId`, `transformer`, `userId?`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:15972](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15972)
+Defined in: [neurolink.ts:15971](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15971)
 
 Modify the last assistant message in a session using a transformer function.
 Convenience wrapper around getSessionMessages/setSessionMessages.
@@ -2415,7 +2415,7 @@ true if a message was modified, false if no assistant message was found
 
 > **addExternalMCPServer**(`serverId`, `config`): `Promise`\<[`ExternalMCPOperationResult`](../type-aliases/ExternalMCPOperationResult.md)\<[`ExternalMCPServerInstance`](../type-aliases/ExternalMCPServerInstance.md)\>\>
 
-Defined in: [neurolink.ts:16003](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16003)
+Defined in: [neurolink.ts:16002](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16002)
 
 Add an external MCP server
 Automatically discovers and registers tools from the server
@@ -2446,7 +2446,7 @@ Operation result with server instance
 
 > **removeExternalMCPServer**(`serverId`): `Promise`\<[`ExternalMCPOperationResult`](../type-aliases/ExternalMCPOperationResult.md)\<`void`\>\>
 
-Defined in: [neurolink.ts:16090](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16090)
+Defined in: [neurolink.ts:16089](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16089)
 
 Remove an external MCP server
 Stops the server and removes all its tools
@@ -2471,7 +2471,7 @@ Operation result
 
 > **listExternalMCPServers**(): `object`[]
 
-Defined in: [neurolink.ts:16142](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16142)
+Defined in: [neurolink.ts:16141](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16141)
 
 List all external MCP servers
 
@@ -2487,7 +2487,7 @@ Array of server health information
 
 > **getExternalMCPServer**(`serverId`): [`ExternalMCPServerInstance`](../type-aliases/ExternalMCPServerInstance.md) \| `undefined`
 
-Defined in: [neurolink.ts:16171](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16171)
+Defined in: [neurolink.ts:16170](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16170)
 
 Get external MCP server status
 
@@ -2511,7 +2511,7 @@ Server instance or undefined if not found
 
 > **executeExternalMCPTool**(`serverId`, `requestedToolName`, `parameters`, `options?`): `Promise`\<`unknown`\>
 
-Defined in: [neurolink.ts:16185](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16185)
+Defined in: [neurolink.ts:16184](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16184)
 
 Execute a tool from an external MCP server
 
@@ -2553,7 +2553,7 @@ Tool execution result
 
 > **getExternalMCPTools**(): [`ExternalMCPToolInfo`](../type-aliases/ExternalMCPToolInfo.md)[]
 
-Defined in: [neurolink.ts:16384](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16384)
+Defined in: [neurolink.ts:16383](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16383)
 
 Get all tools from external MCP servers
 
@@ -2569,7 +2569,7 @@ Array of external tool information
 
 > **getExternalMCPServerTools**(`serverId`): [`ExternalMCPToolInfo`](../type-aliases/ExternalMCPToolInfo.md)[]
 
-Defined in: [neurolink.ts:16393](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16393)
+Defined in: [neurolink.ts:16392](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16392)
 
 Get tools from a specific external MCP server
 
@@ -2593,7 +2593,7 @@ Array of tool information for the server
 
 > **testExternalMCPConnection**(`config`): `Promise`\<[`BatchOperationResult`](../type-aliases/BatchOperationResult.md)\>
 
-Defined in: [neurolink.ts:16402](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16402)
+Defined in: [neurolink.ts:16401](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16401)
 
 Test connection to an external MCP server
 
@@ -2617,7 +2617,7 @@ Test result with connection status
 
 > **getExternalMCPStatistics**(): `object`
 
-Defined in: [neurolink.ts:16430](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16430)
+Defined in: [neurolink.ts:16429](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16429)
 
 Get external MCP server manager statistics
 
@@ -2657,7 +2657,7 @@ Statistics about external servers and tools
 
 > **shutdownExternalMCPServers**(): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:16445](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16445)
+Defined in: [neurolink.ts:16444](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16444)
 
 Shutdown all external MCP servers
 Called automatically on process exit
@@ -2672,7 +2672,7 @@ Called automatically on process exit
 
 > **getElicitationManager**(): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16483](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16483)
+Defined in: [neurolink.ts:16482](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16482)
 
 Get the global elicitation manager for interactive tool input
 Elicitation allows tools to request additional information from users during execution
@@ -2703,7 +2703,7 @@ elicitationManager.registerHandler(async (request) => {
 
 > **registerElicitationHandler**(`handler`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:16511](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16511)
+Defined in: [neurolink.ts:16510](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16510)
 
 Register an elicitation handler for interactive tool input
 Handlers are called when tools need user input during execution
@@ -2741,7 +2741,7 @@ neurolink.registerElicitationHandler(async (request) => {
 
 > **getMultiServerManager**(): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16534](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16534)
+Defined in: [neurolink.ts:16533](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16533)
 
 Get the multi-server manager for load balancing and coordination
 Allows managing multiple MCP servers with failover and load balancing
@@ -2770,7 +2770,7 @@ await multiServer.createServerGroup("ai-tools", {
 
 > **getEnhancedToolDiscovery**(): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16559](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16559)
+Defined in: [neurolink.ts:16558](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16558)
 
 Get the enhanced tool discovery service
 Provides advanced search, filtering, and compatibility checking for tools
@@ -2800,7 +2800,7 @@ const results = await discovery.searchTools({
 
 > **getMCPRegistryClient**(): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16586](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16586)
+Defined in: [neurolink.ts:16585](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16585)
 
 Get the MCP registry client for discovering servers from registries
 Supports multiple registry sources (official, community, custom)
@@ -2832,7 +2832,7 @@ const githubServer = registryClient.getWellKnownServer("github");
 
 > **exposeAgentAsTool**(`agent`, `options?`): `Promise`\<[`ExposureResult`](../type-aliases/ExposureResult.md)\>
 
-Defined in: [neurolink.ts:16614](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16614)
+Defined in: [neurolink.ts:16613](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16613)
 
 Expose a NeuroLink agent as an MCP tool
 This allows agents to be called by other systems via MCP
@@ -2909,7 +2909,7 @@ const tool = await neurolink.exposeAgentAsTool(agent, {
 
 > **exposeWorkflowAsTool**(`workflow`, `options?`): `Promise`\<[`ExposureResult`](../type-aliases/ExposureResult.md)\>
 
-Defined in: [neurolink.ts:16655](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16655)
+Defined in: [neurolink.ts:16654](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16654)
 
 Expose a workflow as an MCP tool
 This allows workflows to be called by other systems via MCP
@@ -2990,7 +2990,7 @@ const tool = await neurolink.exposeWorkflowAsTool(workflow, {
 
 > **getToolIntegrationManager**(): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16694](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16694)
+Defined in: [neurolink.ts:16693](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16693)
 
 Get the tool integration manager for middleware and elicitation
 Provides advanced tool wrapping with confirmation, timeout, retry, etc.
@@ -3020,7 +3020,7 @@ integration.registerTool(myTool, {
 
 > **convertToolsToMCPFormat**(`tools`, `options?`): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16716](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16716)
+Defined in: [neurolink.ts:16715](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16715)
 
 Convert NeuroLink tools to MCP format
 Useful for exposing local tools to external MCP clients
@@ -3061,7 +3061,7 @@ const mcpTools = neurolink.convertToolsToMCPFormat([
 
 > **convertToolsFromMCPFormat**(`tools`, `options?`): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16755](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16755)
+Defined in: [neurolink.ts:16754](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16754)
 
 Convert MCP tools to NeuroLink format
 Useful for importing tools from external MCP servers
@@ -3102,7 +3102,7 @@ const neurolinkTools = neurolink.convertToolsFromMCPFormat(externalTools, {
 
 > **getToolAnnotations**(`toolName`): `Promise`\<\{ `annotations`: [`MCPToolAnnotations`](../type-aliases/MCPToolAnnotations.md); `summary`: `string`; \} \| `null`\>
 
-Defined in: [neurolink.ts:16778](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16778)
+Defined in: [neurolink.ts:16777](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16777)
 
 Get tool annotations and safety information
 Provides insights about tool behavior, safety levels, and retry-ability
@@ -3134,7 +3134,7 @@ const annotations = await neurolink.getToolAnnotations("deleteFile");
 
 > **createEvaluationPipeline**(`configOrPreset`): `Promise`\<[`EvaluationPipeline`](EvaluationPipeline.md)\>
 
-Defined in: [neurolink.ts:17017](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17017)
+Defined in: [neurolink.ts:17016](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17016)
 
 Create an evaluation pipeline with the specified configuration or preset.
 Pipelines orchestrate multiple scorers to evaluate AI responses comprehensively.
@@ -3185,7 +3185,7 @@ const pipeline = await neurolink.createEvaluationPipeline({
 
 > **evaluate**(`input`, `options?`): `Promise`\<[`PipelineResult`](../type-aliases/PipelineResult.md)\>
 
-Defined in: [neurolink.ts:17109](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17109)
+Defined in: [neurolink.ts:17108](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17108)
 
 Evaluate an AI response using the specified pipeline or scorers.
 This is a convenience method that creates a pipeline and executes it in one call.
@@ -3287,7 +3287,7 @@ const result = await neurolink.evaluate(
 
 > **score**(`scorerId`, `input`, `config?`): `Promise`\<[`ScoreResult`](../type-aliases/ScoreResult.md)\>
 
-Defined in: [neurolink.ts:17247](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17247)
+Defined in: [neurolink.ts:17246](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17246)
 
 Score a response using a single scorer.
 Useful for quick, targeted evaluations without the overhead of a full pipeline.
@@ -3356,7 +3356,7 @@ const result = await neurolink.score(
 
 > **getAvailableScorers**(`options?`): `Promise`\<[`ScorerMetadata`](../type-aliases/ScorerMetadata.md)[]\>
 
-Defined in: [neurolink.ts:17333](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17333)
+Defined in: [neurolink.ts:17332](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17332)
 
 Get a list of all available scorers and their metadata.
 Useful for discovering what evaluation capabilities are available.
@@ -3417,7 +3417,7 @@ const ruleBasedScorers = await neurolink.getAvailableScorers({
 
 > **getEvaluationPresets**(): `Promise`\<`string`[]\>
 
-Defined in: [neurolink.ts:17379](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17379)
+Defined in: [neurolink.ts:17378](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17378)
 
 Get a list of available evaluation pipeline presets.
 Presets are pre-configured pipelines for common evaluation scenarios.
@@ -3443,7 +3443,7 @@ console.log("Available presets:", presets);
 
 > **getEvaluationPreset**(`presetName`): `Promise`\<[`PipelineConfig`](../type-aliases/PipelineConfig.md)\>
 
-Defined in: [neurolink.ts:17402](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17402)
+Defined in: [neurolink.ts:17401](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17401)
 
 Get details of a specific evaluation preset.
 
@@ -3479,7 +3479,7 @@ console.log("Pass threshold:", ragPreset.passThreshold);
 
 > **createAgent**(`definition`): `Promise`\<[`Agent`](Agent.md)\>
 
-Defined in: [neurolink.ts:17452](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17452)
+Defined in: [neurolink.ts:17451](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17451)
 
 Create an Agent instance for multi-agent orchestration.
 
@@ -3531,7 +3531,7 @@ const result = await researcher.execute("Find recent AI breakthroughs");
 
 > **createNetwork**(`config`): `Promise`\<[`AgentNetwork`](AgentNetwork.md)\>
 
-Defined in: [neurolink.ts:17514](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17514)
+Defined in: [neurolink.ts:17513](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17513)
 
 Create an AgentNetwork for multi-agent orchestration.
 
@@ -3605,7 +3605,7 @@ const result = await network.execute({
 
 > **createWorkerInstance**(`options?`): `NeuroLink`
 
-Defined in: [neurolink.ts:17546](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17546)
+Defined in: [neurolink.ts:17545](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17545)
 
 Create a worker-mode NeuroLink instance for sub-agent execution.
 
@@ -3645,7 +3645,7 @@ A new worker-mode NeuroLink instance
 
 > **runIsolatedAgent**(`definition`, `input`, `options?`): `Promise`\<[`AgentRunOutcome`](../type-aliases/AgentRunOutcome.md)\>
 
-Defined in: [neurolink.ts:17645](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17645)
+Defined in: [neurolink.ts:17644](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17644)
 
 Run an isolated sub-agent: a worker instance (see
 [createWorkerInstance](#createworkerinstance)) executes a tool-using research pass under
@@ -3695,7 +3695,7 @@ The run outcome
 
 > **continueAgent**(`handle`, `guidance?`): `Promise`\<[`AgentRunOutcome`](../type-aliases/AgentRunOutcome.md)\>
 
-Defined in: [neurolink.ts:17664](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17664)
+Defined in: [neurolink.ts:17663](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17663)
 
 Resume a leashed isolated-agent run by handle. `guidance`, when given,
 is appended as a user turn before the next leg — the supervisor's
@@ -3728,7 +3728,7 @@ The next leg's outcome (or the final outcome)
 
 > **stopAgent**(`handle`): `Promise`\<[`AgentRunOutcome`](../type-aliases/AgentRunOutcome.md)\>
 
-Defined in: [neurolink.ts:17680](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17680)
+Defined in: [neurolink.ts:17679](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17679)
 
 Stop a leashed isolated-agent run: dispose its worker and return the
 final outcome (mechanical digest over everything gathered so far).
@@ -3753,7 +3753,7 @@ The final outcome
 
 > **registerAgentTool**(`definition`, `options?`): `Promise`\<\{ `name`: `string`; \}\>
 
-Defined in: [neurolink.ts:17698](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17698)
+Defined in: [neurolink.ts:17697](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17697)
 
 Register an isolated agent as a delegation tool on THIS instance, so
 its existing generate() loop can delegate — no second router generate.
@@ -3791,7 +3791,7 @@ The registered tool name
 
 > **registerTaskTools**(): `void`
 
-Defined in: [neurolink.ts:17731](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17731)
+Defined in: [neurolink.ts:17730](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17730)
 
 Register the task CHECKLIST toolset — `tasks_create`, `tasks_update`,
 `tasks_list` — on this instance (TodoWrite-style planning for a
@@ -3827,7 +3827,7 @@ id for that one call.
 
 > **getTaskState**(`sessionId?`): [`ChecklistState`](../type-aliases/ChecklistState.md)
 
-Defined in: [neurolink.ts:17757](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17757)
+Defined in: [neurolink.ts:17756](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17756)
 
 Read a session's task checklist — synchronous, so a completeness gate is
 one line of host code:
@@ -3853,7 +3853,7 @@ instance's tool-context session, or its default checklist).
 
 > **clearTaskState**(`sessionId?`): `boolean`
 
-Defined in: [neurolink.ts:17765](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17765)
+Defined in: [neurolink.ts:17764](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17764)
 
 Drop a session's checklist. Returns whether there was one to drop.
 Omit `sessionId` to clear the session the tools currently write to.
@@ -3874,7 +3874,7 @@ Omit `sessionId` to clear the session the tools currently write to.
 
 > **registerDelegationTools**(`options?`): `void`
 
-Defined in: [neurolink.ts:17792](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17792)
+Defined in: [neurolink.ts:17791](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17791)
 
 Register the background-delegation toolset — `delegate_task` and
 `collect_results` — on this instance. Opt-in and idempotent: existing
@@ -3913,7 +3913,7 @@ Depth ceiling, pool raise, and queue wait
 
 > **spawnDelegate**(`options`): `Promise`\<[`DelegateHandle`](../type-aliases/DelegateHandle.md)\>
 
-Defined in: [neurolink.ts:17832](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17832)
+Defined in: [neurolink.ts:17831](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17831)
 
 Start a background worker and get its handle immediately — before it has
 run anything, and long before it finishes.
@@ -3957,7 +3957,7 @@ when the task is empty or the caller is at the depth ceiling
 
 > **collectDelegates**(`request`): `Promise`\<[`DelegateCollectResult`](../type-aliases/DelegateCollectResult.md)\>
 
-Defined in: [neurolink.ts:17843](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17843)
+Defined in: [neurolink.ts:17842](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17842)
 
 Claim finished background workers — in COMPLETION order, which has nothing
 to do with spawn order. Each outcome is handed out exactly once.
@@ -3982,7 +3982,7 @@ Claimed outcomes plus what is still pending/ready
 
 > **cancelDelegates**(`workerId?`): `Promise`\<`number`\>
 
-Defined in: [neurolink.ts:17857](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17857)
+Defined in: [neurolink.ts:17856](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17856)
 
 Cancel background workers: one by id, or every outstanding worker this
 instance spawned. Cancelled workers still settle into a claimable outcome
@@ -4008,7 +4008,7 @@ How many workers were cancelled
 
 > **getArtifactStore**(): [`ArtifactStore`](../type-aliases/ArtifactStore.md)
 
-Defined in: [neurolink.ts:17880](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17880)
+Defined in: [neurolink.ts:17879](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17879)
 
 This instance's artifact store, created on first use.
 
@@ -4034,7 +4034,7 @@ The artifact store backing [bankArtifact](#bankartifact) / [readArtifact](#reada
 
 > **setArtifactStore**(`store`): `void`
 
-Defined in: [neurolink.ts:17910](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17910)
+Defined in: [neurolink.ts:17909](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17909)
 
 Replace this instance's artifact store.
 
@@ -4072,7 +4072,7 @@ Any [ArtifactStore](../type-aliases/ArtifactStore.md)
 
 > **bankArtifact**(`payload`, `options`): `Promise`\<[`BankedArtifactRef`](../type-aliases/BankedArtifactRef.md)\>
 
-Defined in: [neurolink.ts:17998](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17998)
+Defined in: [neurolink.ts:17997](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17997)
 
 Bank a payload to a file and get back a pointer to it.
 
@@ -4119,7 +4119,7 @@ const ref = await neurolink.bankArtifact(fullReport, {
 
 > **readArtifact**(`id`, `page?`): `Promise`\<`string` \| `null`\>
 
-Defined in: [neurolink.ts:18015](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18015)
+Defined in: [neurolink.ts:18014](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18014)
 
 Read a banked payload back from host code — the programmatic twin of the
 model's `retrieve_context({ artifactId })` call.
@@ -4151,7 +4151,7 @@ Optional character window
 
 > **registerBackgroundCommandTools**(`policy`): `void`
 
-Defined in: [neurolink.ts:18047](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18047)
+Defined in: [neurolink.ts:18046](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18046)
 
 Register the background-command toolset — `run_command_bg`,
 `command_status`, `command_output`, `command_kill` — on this instance, and
@@ -4192,7 +4192,7 @@ What may run, where, for how long, and how loudly
 
 > **setBackgroundCommandPolicy**(`policy`): `void`
 
-Defined in: [neurolink.ts:18072](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18072)
+Defined in: [neurolink.ts:18071](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18071)
 
 Declare (or replace) what this instance may execute, without registering
 the model-facing tools. Host code that only drives
@@ -4216,7 +4216,7 @@ What may run, where, for how long, and how loudly
 
 > **startBackgroundCommand**(`argv`, `options`): `Promise`\<[`BackgroundCommandHandle`](../type-aliases/BackgroundCommandHandle.md)\>
 
-Defined in: [neurolink.ts:18096](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18096)
+Defined in: [neurolink.ts:18095](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18095)
 
 Start a command in the background and get its task id immediately.
 
@@ -4263,7 +4263,7 @@ allowlisted, the policy vetoes it, or the cwd escapes the sandbox
 
 > **getBackgroundCommandStatus**(`taskId`): [`BackgroundCommandStatus`](../type-aliases/BackgroundCommandStatus.md)
 
-Defined in: [neurolink.ts:18110](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18110)
+Defined in: [neurolink.ts:18109](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18109)
 
 Everything known about one command right now — synchronous, so a
 mid-loop monitor costs nothing.
@@ -4290,7 +4290,7 @@ when the task id is unknown to this instance
 
 > **awaitBackgroundCommand**(`taskId`, `opts?`): `Promise`\<[`BackgroundCommandStatus`](../type-aliases/BackgroundCommandStatus.md)\>
 
-Defined in: [neurolink.ts:18122](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18122)
+Defined in: [neurolink.ts:18121](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18121)
 
 Wait for a command to settle. `timeoutMs` bounds the WAIT, not the
 command: when it elapses the current status is returned rather than
@@ -4322,7 +4322,7 @@ Task id from [startBackgroundCommand](#startbackgroundcommand)
 
 > **killBackgroundCommand**(`taskId`, `signal?`): `Promise`\<[`BackgroundCommandStatus`](../type-aliases/BackgroundCommandStatus.md)\>
 
-Defined in: [neurolink.ts:18137](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18137)
+Defined in: [neurolink.ts:18136](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18136)
 
 Kill a running command — SIGTERM, then SIGKILL five seconds later — and
 resolve with its settled status. Whatever it printed first is still
@@ -4352,7 +4352,7 @@ Signal to send first. Default SIGTERM
 
 > **readBackgroundCommandOutput**(`taskId`, `page`): `Promise`\<[`BackgroundCommandOutputPage`](../type-aliases/BackgroundCommandOutputPage.md)\>
 
-Defined in: [neurolink.ts:18152](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18152)
+Defined in: [neurolink.ts:18151](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18151)
 
 Read one character window of a command's output straight from its log
 file — while it is still running, or long after it finished. Offsets,
@@ -4382,7 +4382,7 @@ Which stream, and which window of it
 
 > **registerGitTools**(`options`): `void`
 
-Defined in: [neurolink.ts:18179](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18179)
+Defined in: [neurolink.ts:18178](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18178)
 
 Register the read-only git toolset — `git_log`, `git_show`, `git_diff`,
 `git_blame`, `git_merge_base`, `git_ls_files` — on this instance. Opt-in
@@ -4415,7 +4415,7 @@ Repository root, plus timeout / byte-cap / preview bounds
 
 > **runGitCommand**(`args`, `sessionId?`): `Promise`\<[`GitToolResult`](../type-aliases/GitToolResult.md)\>
 
-Defined in: [neurolink.ts:18205](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18205)
+Defined in: [neurolink.ts:18204](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18204)
 
 Run one read-only git command from host code, with the same bounding the
 tools get: the complete stdout is banked, the result carries a preview and
@@ -4450,7 +4450,7 @@ when [registerGitTools](#registergittools) has not been called
 
 > **executeNetwork**(`network`, `input`, `options?`): `Promise`\<[`NetworkExecutionResult`](../type-aliases/NetworkExecutionResult.md)\>
 
-Defined in: [neurolink.ts:18224](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18224)
+Defined in: [neurolink.ts:18223](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18223)
 
 Execute an agent network with the given input.
 
@@ -4495,7 +4495,7 @@ Network execution result with content, trace, and usage
 
 > **streamNetwork**(`network`, `input`, `options?`): `AsyncIterable`\<[`NetworkStreamChunk`](../type-aliases/NetworkStreamChunk.md)\>
 
-Defined in: [neurolink.ts:18248](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18248)
+Defined in: [neurolink.ts:18247](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18247)
 
 Stream agent network execution with real-time events.
 
@@ -4539,7 +4539,7 @@ Async iterable of network stream chunks
 
 > **createOrchestrator**(`config?`): `Promise`\<[`NetworkOrchestrator`](NetworkOrchestrator.md)\>
 
-Defined in: [neurolink.ts:18272](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18272)
+Defined in: [neurolink.ts:18271](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18271)
 
 Create a NetworkOrchestrator for managing multiple agent networks.
 
@@ -4567,7 +4567,7 @@ A new NetworkOrchestrator instance
 
 > **createCoordinator**(`config?`): `Promise`\<[`AgentCoordinator`](AgentCoordinator.md)\>
 
-Defined in: [neurolink.ts:18291](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18291)
+Defined in: [neurolink.ts:18290](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18290)
 
 Create an AgentCoordinator for managing agent coordination strategies.
 
@@ -4595,7 +4595,7 @@ A new AgentCoordinator instance
 
 > **createMessageBus**(`config?`): `Promise`\<[`MessageBus`](MessageBus.md)\>
 
-Defined in: [neurolink.ts:18309](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18309)
+Defined in: [neurolink.ts:18308](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18308)
 
 Create a MessageBus for inter-agent communication.
 
@@ -4623,7 +4623,7 @@ A new MessageBus instance
 
 > **dispose**(): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:18324](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18324)
+Defined in: [neurolink.ts:18323](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18323)
 
 Dispose of all resources and cleanup connections
 Call this method when done using the NeuroLink instance to prevent resource leaks
@@ -4639,7 +4639,7 @@ Especially important in test environments where multiple instances are created
 
 > **getToolRegistry**(): [`MCPToolRegistry`](MCPToolRegistry.md)
 
-Defined in: [neurolink.ts:18543](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18543)
+Defined in: [neurolink.ts:18542](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18542)
 
 Get the tool registry instance
 Used internally by server adapters for tool management
@@ -4656,7 +4656,7 @@ The MCPToolRegistry instance
 
 > **compactSession**(`sessionId`, `config?`): `Promise`\<[`CompactionResult`](../type-aliases/CompactionResult.md) \| `null`\>
 
-Defined in: [neurolink.ts:18551](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18551)
+Defined in: [neurolink.ts:18550](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18550)
 
 Manually trigger context compaction for a session.
 Runs the full 4-stage compaction pipeline.
@@ -4681,7 +4681,7 @@ Runs the full 4-stage compaction pipeline.
 
 > **getContextStats**(`sessionId`, `provider?`, `model?`): `Promise`\<\{ `estimatedInputTokens`: `number`; `availableInputTokens`: `number`; `usageRatio`: `number`; `shouldCompact`: `boolean`; `messageCount`: `number`; \} \| `null`\>
 
-Defined in: [neurolink.ts:18602](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18602)
+Defined in: [neurolink.ts:18601](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18601)
 
 Get context usage statistics for a session.
 Returns token counts, usage ratio, and breakdown by category.
@@ -4710,7 +4710,7 @@ Returns token counts, usage ratio, and breakdown by category.
 
 > **needsCompaction**(`sessionId`, `provider?`, `model?`): `boolean`
 
-Defined in: [neurolink.ts:18644](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18644)
+Defined in: [neurolink.ts:18643](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18643)
 
 Check if a session needs compaction.
 
@@ -4738,7 +4738,7 @@ Check if a session needs compaction.
 
 > **setAuthProvider**(`config`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:18681](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18681)
+Defined in: [neurolink.ts:18680](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18680)
 
 Set the authentication provider for the NeuroLink instance
 
@@ -4760,7 +4760,7 @@ Auth provider or configuration to create one
 
 > **getAuthProvider**(): [`AuthProvider`](../type-aliases/AuthProvider.md) \| `undefined`
 
-Defined in: [neurolink.ts:18729](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18729)
+Defined in: [neurolink.ts:18728](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18728)
 
 Get the currently configured authentication provider
 
@@ -4774,7 +4774,7 @@ Get the currently configured authentication provider
 
 > **setAuthContext**(`context`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:18770](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18770)
+Defined in: [neurolink.ts:18769](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18769)
 
 Set the current authentication context for request handling.
 
@@ -4801,7 +4801,7 @@ The authenticated user context
 
 > **getAuthContext**(): `Promise`\<[`AuthenticatedContext`](../type-aliases/AuthenticatedContext.md) \| `undefined`\>
 
-Defined in: [neurolink.ts:18785](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18785)
+Defined in: [neurolink.ts:18784](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18784)
 
 Get the current authentication context.
 
@@ -4817,7 +4817,7 @@ Checks AsyncLocalStorage first, then falls back to the global holder.
 
 > **clearAuthContext**(): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:18793](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18793)
+Defined in: [neurolink.ts:18792](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18792)
 
 Clear the current authentication context
 
@@ -4831,7 +4831,7 @@ Clear the current authentication context
 
 > **getExternalServerManager**(): [`ExternalServerManager`](ExternalServerManager.md)
 
-Defined in: [neurolink.ts:18807](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18807)
+Defined in: [neurolink.ts:18806](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18806)
 
 Get the external server manager instance
 Used internally by server adapters for external MCP server management

--- a/docs/api/type-aliases/NativeGenerateLoopResult.md
+++ b/docs/api/type-aliases/NativeGenerateLoopResult.md
@@ -20,11 +20,21 @@ Defined in: [types/generate.ts:1796](https://github.com/juspay/neurolink/blob/re
 
 ---
 
+### reasoning?
+
+> `optional` **reasoning?**: `string`
+
+Defined in: [types/generate.ts:1798](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1798)
+
+Joined reasoning content parts from the final step, when the vendor sent any.
+
+---
+
 ### finishReason
 
 > **finishReason**: `string`
 
-Defined in: [types/generate.ts:1797](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1797)
+Defined in: [types/generate.ts:1799](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1799)
 
 ---
 
@@ -32,7 +42,7 @@ Defined in: [types/generate.ts:1797](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **rawFinishReason?**: `string`
 
-Defined in: [types/generate.ts:1798](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1798)
+Defined in: [types/generate.ts:1800](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1800)
 
 ---
 
@@ -40,7 +50,7 @@ Defined in: [types/generate.ts:1798](https://github.com/juspay/neurolink/blob/re
 
 > **inputTokens**: `number`
 
-Defined in: [types/generate.ts:1799](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1799)
+Defined in: [types/generate.ts:1801](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1801)
 
 ---
 
@@ -48,7 +58,7 @@ Defined in: [types/generate.ts:1799](https://github.com/juspay/neurolink/blob/re
 
 > **outputTokens**: `number`
 
-Defined in: [types/generate.ts:1800](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1800)
+Defined in: [types/generate.ts:1802](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1802)
 
 ---
 
@@ -56,7 +66,7 @@ Defined in: [types/generate.ts:1800](https://github.com/juspay/neurolink/blob/re
 
 > **cacheReadTokens**: `number`
 
-Defined in: [types/generate.ts:1801](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1801)
+Defined in: [types/generate.ts:1803](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1803)
 
 ---
 
@@ -64,7 +74,7 @@ Defined in: [types/generate.ts:1801](https://github.com/juspay/neurolink/blob/re
 
 > **cacheWriteTokens**: `number`
 
-Defined in: [types/generate.ts:1802](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1802)
+Defined in: [types/generate.ts:1804](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1804)
 
 ---
 
@@ -72,7 +82,7 @@ Defined in: [types/generate.ts:1802](https://github.com/juspay/neurolink/blob/re
 
 > **toolsUsed**: `string`[]
 
-Defined in: [types/generate.ts:1803](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1803)
+Defined in: [types/generate.ts:1805](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1805)
 
 ---
 
@@ -80,4 +90,4 @@ Defined in: [types/generate.ts:1803](https://github.com/juspay/neurolink/blob/re
 
 > **steps**: `number`
 
-Defined in: [types/generate.ts:1804](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1804)
+Defined in: [types/generate.ts:1806](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1806)

--- a/docs/api/type-aliases/SingleShotRequest.md
+++ b/docs/api/type-aliases/SingleShotRequest.md
@@ -8,7 +8,7 @@
 
 > **SingleShotRequest** = `object`
 
-Defined in: [types/generate.ts:1807](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1807)
+Defined in: [types/generate.ts:1809](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1809)
 
 ## Properties
 
@@ -16,7 +16,7 @@ Defined in: [types/generate.ts:1807](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **system?**: `string`
 
-Defined in: [types/generate.ts:1808](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1808)
+Defined in: [types/generate.ts:1810](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1810)
 
 ---
 
@@ -24,7 +24,7 @@ Defined in: [types/generate.ts:1808](https://github.com/juspay/neurolink/blob/re
 
 > **prompt**: `string`
 
-Defined in: [types/generate.ts:1809](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1809)
+Defined in: [types/generate.ts:1811](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1811)
 
 ---
 
@@ -32,7 +32,7 @@ Defined in: [types/generate.ts:1809](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **maxOutputTokens?**: `number`
 
-Defined in: [types/generate.ts:1810](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1810)
+Defined in: [types/generate.ts:1812](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1812)
 
 ---
 
@@ -40,7 +40,7 @@ Defined in: [types/generate.ts:1810](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **temperature?**: `number`
 
-Defined in: [types/generate.ts:1811](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1811)
+Defined in: [types/generate.ts:1813](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1813)
 
 ---
 
@@ -48,4 +48,4 @@ Defined in: [types/generate.ts:1811](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **abortSignal?**: `AbortSignal`
 
-Defined in: [types/generate.ts:1812](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1812)
+Defined in: [types/generate.ts:1814](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1814)

--- a/docs/api/type-aliases/SingleShotResult.md
+++ b/docs/api/type-aliases/SingleShotResult.md
@@ -8,7 +8,7 @@
 
 > **SingleShotResult** = `object`
 
-Defined in: [types/generate.ts:1815](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1815)
+Defined in: [types/generate.ts:1817](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1817)
 
 ## Properties
 
@@ -16,7 +16,7 @@ Defined in: [types/generate.ts:1815](https://github.com/juspay/neurolink/blob/re
 
 > **text**: `string`
 
-Defined in: [types/generate.ts:1816](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1816)
+Defined in: [types/generate.ts:1818](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1818)
 
 ---
 
@@ -24,7 +24,7 @@ Defined in: [types/generate.ts:1816](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **usage?**: `object`
 
-Defined in: [types/generate.ts:1817](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1817)
+Defined in: [types/generate.ts:1819](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1819)
 
 #### inputTokens?
 
@@ -44,4 +44,4 @@ Defined in: [types/generate.ts:1817](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **finishReason?**: `string`
 
-Defined in: [types/generate.ts:1818](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1818)
+Defined in: [types/generate.ts:1820](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1820)

--- a/src/lib/core/baseProvider.ts
+++ b/src/lib/core/baseProvider.ts
@@ -2205,11 +2205,9 @@ export abstract class BaseProvider implements AIProvider {
       analytics: result.analytics,
       evaluation: result.evaluation,
       audio: result.audio,
-      // Forward reasoning fields from the provider result (DeepSeek
-      // `reasoning_content`, Anthropic thinking, Gemini thought parts,
-      // OpenAI o1). Providers on the shared native generate loop do not
-      // populate them yet: the loop emits a V3 reasoning content part but
-      // nothing joins it into `reasoning`, so this forwards undefined there.
+      // Forward reasoning fields populated by the native generate loop from
+      // vendor reasoning parts (DeepSeek `reasoning_content`, Anthropic
+      // thinking, Gemini thought parts, OpenAI o1).
       reasoning: result.reasoning,
       reasoningTokens: result.reasoningTokens,
     };

--- a/src/lib/core/nativeGenerateLoop.ts
+++ b/src/lib/core/nativeGenerateLoop.ts
@@ -136,6 +136,7 @@ export async function runNativeGenerateLoop(
 ): Promise<NativeGenerateLoopResult> {
   const toolsUsed: string[] = [];
   let text = "";
+  let reasoning = "";
   let finishReason = "stop";
   let rawFinishReason: string | undefined;
   let inputTokens = 0;
@@ -224,6 +225,15 @@ export async function runNativeGenerateLoop(
     // answer is the turn's answer, matching what generateText reported.
     text = parts
       .filter((p) => p.type === "text" && typeof p.text === "string")
+      .map((p) => p.text as string)
+      .join("");
+    // Reasoner models (DeepSeek `reasoning_content`, gateway `reasoning`,
+    // OpenAI o-series) emit reasoning as its own V3 content part. Join it on
+    // the same replace-per-step rule as the text so the caller can surface
+    // `result.reasoning`; without this the provider builds the part and the
+    // loop drops it.
+    reasoning = parts
+      .filter((p) => p.type === "reasoning" && typeof p.text === "string")
       .map((p) => p.text as string)
       .join("");
 
@@ -352,6 +362,7 @@ export async function runNativeGenerateLoop(
 
   return {
     text,
+    ...(reasoning ? { reasoning } : {}),
     finishReason,
     ...(rawFinishReason ? { rawFinishReason } : {}),
     inputTokens,

--- a/src/lib/core/nativeToolFormat.ts
+++ b/src/lib/core/nativeToolFormat.ts
@@ -71,9 +71,8 @@ export function toNativeToolDeclarations(
         ? convertZodToJsonSchema(rawSchema as never)
         : { type: "object", properties: {} }
     ) as Record<string, unknown>;
-    // Honor a cache breakpoint if a caller marked this tool. Nothing marks
-    // the last tool definition today: that was GenerationHandler's job and it
-    // went with the ai-package path, so this currently reads undefined.
+    // Honor a cache breakpoint the caller set on this tool. The direct
+    // Anthropic path marks the last tool itself, on the assembled request.
     const cc = cacheControlOf(tool);
     const declaration: NativeAnthropicToolDeclaration = {
       name,

--- a/src/lib/neurolink.ts
+++ b/src/lib/neurolink.ts
@@ -5900,14 +5900,13 @@ Current user's request: ${currentInput}`;
       avatar: textResult.avatar,
       music: textResult.music,
       ppt: textResult.ppt,
-      // Forward reasoning/reasoningTokens from the provider layer. They are
-      // declared on `GenerateResult` (DeepSeek's `reasoning_content`,
-      // Anthropic thinking blocks, Gemini thought parts, OpenAI o1) and the
-      // builder used to drop them on the floor, so callers asking for
-      // `result.reasoning` got `undefined` even when the model emitted a
-      // chain-of-thought. Providers on the shared native generate loop still
-      // do not populate the field — openaiChatCompletionsBase's doGenerate
-      // emits the reasoning part, but nothing joins it.
+      // Forward reasoning/reasoningTokens from the provider layer.
+      // The native generate loop extracts these from vendor reasoning
+      // parts (DeepSeek's `reasoning_content`, Anthropic thinking blocks,
+      // Gemini thought parts, OpenAI o1) and they're declared on
+      // `GenerateResult`, but the builder previously dropped them on the
+      // floor — so callers asking for `result.reasoning` got `undefined`
+      // even when the model emitted a chain-of-thought.
       reasoning: textResult.reasoning,
       reasoningTokens: textResult.reasoningTokens,
       ...(textResult.retries && { retries: textResult.retries }),

--- a/src/lib/providers/amazonSagemaker.ts
+++ b/src/lib/providers/amazonSagemaker.ts
@@ -284,6 +284,7 @@ export class AmazonSageMakerProvider extends BaseProvider {
         total: loop.inputTokens + loop.outputTokens,
       },
       responseTime: Date.now() - startTime,
+      ...(loop.reasoning ? { reasoning: loop.reasoning } : {}),
       toolsUsed: loop.toolsUsed,
       toolCalls: toolCallsFromSummaries(toolExecutionSummaries),
       toolExecutions: resolveToolExecutionRecords(

--- a/src/lib/providers/anthropic/cacheControl.ts
+++ b/src/lib/providers/anthropic/cacheControl.ts
@@ -3,9 +3,8 @@ import type Anthropic from "@anthropic-ai/sdk";
 /**
  * Read an Anthropic cache breakpoint from a message/part/tool carrier.
  * MessageBuilder marks system messages with
- * `providerOptions.anthropic.cacheControl`. A tool carrier is still read so a
- * marked tool is honored, but nothing marks one today — GenerationHandler
- * tagged the last tool definition and went with the ai-package path.
+ * `providerOptions.anthropic.cacheControl`; the Anthropic client marks the last
+ * tool definition on the assembled request. This reader is what honors both.
  *
  * Extracted from anthropic/client.ts so `src/lib/core/nativeToolFormat.ts`
  * can share it without importing the provider client (which would create a

--- a/src/lib/providers/anthropic/client.ts
+++ b/src/lib/providers/anthropic/client.ts
@@ -1350,9 +1350,8 @@ export class AnthropicProvider extends BaseProvider {
         let tools: Anthropic.Messages.Tool[] | undefined = (options.tools ?? [])
           .filter((t) => t.type === "function")
           .map((t) => {
-            // Honor a cache breakpoint if a caller marked this tool. Nothing
-            // marks the last tool definition today: that was
-            // GenerationHandler's job and it went with the ai-package path.
+            // Honor a cache breakpoint the caller set on this tool. When no
+            // tool carries one, the last tool is marked further below.
             const cc = cacheControlOf(t);
             return {
               name: t.name,
@@ -1420,9 +1419,27 @@ export class AnthropicProvider extends BaseProvider {
           | { type: "enabled"; budget_tokens: number }
           | undefined;
 
+        // Close the stable prefix with a breakpoint on the LAST tool. Tool
+        // definitions sit between the system prompt and the conversation and
+        // rarely change, so without this the whole tools block is re-billed
+        // every turn. Applied after every tool mutation above (including the
+        // appended final_result tool) so the marker really is last, and before
+        // the count below so the history budget accounts for it. A caller that
+        // marked a tool itself wins.
+        if (tools && tools.length > 0) {
+          const alreadyMarked = tools.some((t) => cacheControlOf(t));
+          if (!alreadyMarked) {
+            const last = tools[tools.length - 1];
+            tools = [
+              ...tools.slice(0, -1),
+              { ...last, cache_control: { type: "ephemeral" } },
+            ];
+          }
+        }
+
         // Prompt-cache parity with the native Vertex+Claude path: upstream
-        // layers mark only the stable prefix (the system prompt, via
-        // MessageBuilder) — the growing conversation
+        // layers mark the stable prefix (system via MessageBuilder, and the
+        // last tool just above) — the growing conversation
         // history has no breakpoint, so on every turn it falls after the
         // last marker and is re-billed as fresh input. Add rolling history
         // breakpoints in whatever budget remains under Anthropic's
@@ -1885,6 +1902,7 @@ export class AnthropicProvider extends BaseProvider {
       ...(loop.rawFinishReason
         ? { rawFinishReason: loop.rawFinishReason }
         : {}),
+      ...(loop.reasoning ? { reasoning: loop.reasoning } : {}),
       usage: {
         input: loop.inputTokens,
         output: loop.outputTokens,

--- a/src/lib/providers/openaiChatCompletionsBase.ts
+++ b/src/lib/providers/openaiChatCompletionsBase.ts
@@ -967,10 +967,8 @@ export abstract class OpenAIChatCompletionsProvider extends BaseProvider {
             : "") ?? "";
         const content: Array<{ type: string } & Record<string, unknown>> = [];
         // Reasoner-model output (DeepSeek `reasoning_content`, gateway
-        // `reasoning`) becomes a V3 reasoning part ahead of the text part.
-        // Nothing joins those parts into `result.reasoning` on the generate
-        // path today — GenerationHandler did, and went with the ai-package
-        // path — so the part is emitted here and currently dropped.
+        // `reasoning`) becomes a V3 reasoning part ahead of the text part —
+        // the native generate loop joins those parts into `result.reasoning`.
         // `||` so an empty-string reasoning_content falls through to a
         // non-empty `reasoning` field instead of shadowing it.
         const reasoningText =
@@ -1329,6 +1327,7 @@ export abstract class OpenAIChatCompletionsProvider extends BaseProvider {
           : {}),
       },
       responseTime: Date.now() - startTime,
+      ...(loop.reasoning ? { reasoning: loop.reasoning } : {}),
       toolsUsed,
       toolCalls: toolCallsFromSummaries(toolExecutionSummaries),
       toolExecutions: resolveToolExecutionRecords(

--- a/src/lib/types/generate.ts
+++ b/src/lib/types/generate.ts
@@ -1794,6 +1794,8 @@ export type NativeGenerateLoopArgs = {
 
 export type NativeGenerateLoopResult = {
   text: string;
+  /** Joined reasoning content parts from the final step, when the vendor sent any. */
+  reasoning?: string;
   finishReason: string;
   rawFinishReason?: string;
   inputTokens: number;

--- a/src/lib/utils/anthropicCacheBreakpoints.ts
+++ b/src/lib/utils/anthropicCacheBreakpoints.ts
@@ -86,10 +86,10 @@ export function applyVertexAnthropicCacheBreakpoints(
 /**
  * Count the `cache_control` markers already present on a request. The direct
  * Anthropic path arrives with markers the upstream layers placed —
- * MessageBuilder tags the system prompt, and message content blocks may carry
- * their own. Tool definitions can carry one too, though nothing marks them
- * today. Anthropic rejects requests with more than four markers, so any
- * additional history breakpoints must fit in the remaining budget.
+ * MessageBuilder tags the system prompt, the client tags the last tool
+ * definition, and message content blocks may carry their own. Anthropic
+ * rejects requests with more than four markers, so any additional history
+ * breakpoints must fit in the remaining budget.
  */
 export function countAnthropicCacheMarkers(input: {
   system?: string | ReadonlyArray<{ cache_control?: unknown }> | undefined;
@@ -115,8 +115,8 @@ export function countAnthropicCacheMarkers(input: {
 
 /**
  * Rolling history breakpoints for request paths whose stable-prefix markers
- * are managed upstream (direct Anthropic: the system prompt, via
- * MessageBuilder). Marks the last content block of up to `budget`
+ * are managed upstream (direct Anthropic: system via MessageBuilder, last
+ * tool via the provider client). Marks the last content block of up to `budget`
  * tail messages; a tail block that already carries a marker is left as-is
  * without consuming budget (it already serves as that breakpoint). Pure —
  * the input array is cloned, never mutated.

--- a/test/continuous-test-suite-native-vendor-recovery.ts
+++ b/test/continuous-test-suite-native-vendor-recovery.ts
@@ -33,6 +33,8 @@ import "dotenv/config";
  * Run: pnpm run build && npx tsx test/continuous-test-suite-native-vendor-recovery.ts
  */
 
+import { createServer } from "node:http";
+import { once } from "node:events";
 import { z } from "zod";
 import { defineSuite } from "./helpers/harness.js";
 import { assertDistFresh } from "./helpers/distFreshness.js";
@@ -304,6 +306,198 @@ await test("a native tool round trip populates result.toolCalls", async () => {
     }
   } finally {
     await server.close();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Native-loop result contracts.
+//
+// These are not vendor recoveries: they are fields the loop is supposed to
+// carry that it silently drops. Both were found when the ai-sdk removal's
+// leftover comments were audited — each comment credited `GenerationHandler`
+// with work that nothing does now.
+// ---------------------------------------------------------------------------
+
+await test("a vendor reasoning part reaches result.reasoning", async () => {
+  const REASONING = "step one, then step two";
+  const server = await startScriptedChatServer([
+    {
+      id: "reasoner",
+      object: "chat.completion",
+      created: 1,
+      model: "scripted-reasoner",
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: "assistant",
+            content: "42",
+            reasoning_content: REASONING,
+          },
+          finish_reason: "stop",
+        },
+      ],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    },
+  ]);
+  const sdk = new NeuroLink();
+  try {
+    const result = await sdk.generate({
+      input: { text: "what is the answer?" },
+      provider: "openai",
+      model: "scripted-reasoner",
+      disableTools: true,
+      disableInternalFallback: true,
+      credentials: credentialsFor(server.baseURL),
+    });
+    // Precondition: a pass must not come from the call never happening.
+    if (server.requestCount() !== 1) {
+      throw new Error(
+        "precondition: the scripted endpoint was not called once",
+      );
+    }
+    if (result.content !== "42") {
+      throw new Error(
+        "precondition: the scripted answer did not reach content",
+      );
+    }
+    if (result.reasoning !== REASONING) {
+      throw new Error(
+        "the vendor reasoning part did not reach result.reasoning",
+      );
+    }
+  } finally {
+    await sdk.shutdown();
+    await server.close();
+  }
+});
+
+type AnthropicToolProbe = {
+  baseURL: string;
+  requests(): number;
+  lastTools(): Array<Record<string, unknown>>;
+};
+
+/** Minimal Messages endpoint that records the tool block it was sent. */
+const startAnthropicToolProbe = async (): Promise<AnthropicToolProbe> => {
+  let requests = 0;
+  let tools: Array<Record<string, unknown>> = [];
+  const server = createServer(async (req, res) => {
+    const chunks: Buffer[] = [];
+    for await (const part of req) {
+      chunks.push(part as Buffer);
+    }
+    requests += 1;
+    try {
+      const parsed = JSON.parse(Buffer.concat(chunks).toString("utf8")) as {
+        tools?: Array<Record<string, unknown>>;
+      };
+      tools = parsed.tools ?? [];
+    } catch {
+      tools = [];
+    }
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(
+      JSON.stringify({
+        id: "msg_probe",
+        type: "message",
+        role: "assistant",
+        model: "claude-sonnet-4-20250514",
+        content: [{ type: "text", text: "done" }],
+        stop_reason: "end_turn",
+        stop_sequence: null,
+        usage: { input_tokens: 1, output_tokens: 1 },
+      }),
+    );
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  if (!address || typeof address !== "object") {
+    throw new Error("probe server did not bind");
+  }
+  return {
+    baseURL: `http://127.0.0.1:${address.port}`,
+    requests: () => requests,
+    lastTools: () => tools,
+    close: () =>
+      new Promise<void>((resolve) => {
+        server.closeAllConnections();
+        server.close(() => resolve());
+      }),
+  } as AnthropicToolProbe & { close: () => Promise<void> };
+};
+
+await test("the Anthropic tools block carries one cache breakpoint", async () => {
+  const probe = (await startAnthropicToolProbe()) as AnthropicToolProbe & {
+    close: () => Promise<void>;
+  };
+  const saved = {
+    url: process.env.ANTHROPIC_BASE_URL,
+    key: process.env.ANTHROPIC_API_KEY,
+  };
+  process.env.ANTHROPIC_BASE_URL = probe.baseURL;
+  process.env.ANTHROPIC_API_KEY = "sk-ant-mock-local-server";
+  const sdk = new NeuroLink();
+  try {
+    await sdk.generate({
+      input: { text: "hello" },
+      provider: "anthropic",
+      model: "claude-sonnet-4-20250514",
+      disableInternalFallback: true,
+      tools: {
+        first_tool: tool({
+          description: "first",
+          inputSchema: z.object({ a: z.string() }),
+          execute: async () => "a",
+        }),
+        second_tool: tool({
+          description: "second",
+          inputSchema: z.object({ b: z.string() }),
+          execute: async () => "b",
+        }),
+      },
+    });
+    // Preconditions: the request must actually have carried both tools,
+    // otherwise "no marker" would prove nothing.
+    if (probe.requests() < 1) {
+      throw new Error("precondition: the probe endpoint was never called");
+    }
+    // The SDK merges built-in/MCP tools with the caller's, so assert a floor
+    // rather than an exact count: what matters is that a tools block was sent.
+    const tools = probe.lastTools();
+    if (tools.length < 2) {
+      throw new Error("precondition: the request carried no tools block");
+    }
+    const marked = tools.filter(
+      (t) =>
+        (t as { cache_control?: { type?: string } }).cache_control?.type ===
+        "ephemeral",
+    );
+    if (marked.length !== 1) {
+      throw new Error(
+        "the tools block does not carry exactly one cache breakpoint",
+      );
+    }
+    const last = tools[tools.length - 1] as {
+      cache_control?: { type?: string };
+    };
+    if (last.cache_control?.type !== "ephemeral") {
+      throw new Error("the cache breakpoint is not on the last tool");
+    }
+  } finally {
+    await sdk.shutdown();
+    await probe.close();
+    if (saved.url === undefined) {
+      delete process.env.ANTHROPIC_BASE_URL;
+    } else {
+      process.env.ANTHROPIC_BASE_URL = saved.url;
+    }
+    if (saved.key === undefined) {
+      delete process.env.ANTHROPIC_API_KEY;
+    } else {
+      process.env.ANTHROPIC_API_KEY = saved.key;
+    }
   }
 });
 


### PR DESCRIPTION
## What

Two contracts the native generate loop was supposed to carry and silently dropped.

Both surfaced while auditing the comments the ai-sdk removal left behind ([#1662](https://github.com/juspay/neurolink/pull/1662)): each credited `GenerationHandler` with work that nothing does any more. Deleting that class took the behaviour with it, and nothing noticed because no test covered either one.

## Reasoning never reached the caller

`openaiChatCompletionsBase`'s `doGenerate` builds a V3 `reasoning` content part for reasoner models — DeepSeek `reasoning_content`, gateway `reasoning`, OpenAI o-series — and `runNativeGenerateLoop` never looked at it. It collected only `text` parts.

Every other layer was already wired: `GenerateResult.reasoning` is declared at `generate.ts:1168`, `baseProvider.ts` forwards it, `neurolink.ts` forwards it. The only missing link was the one that fills it, so callers got `undefined` even when the model emitted a chain of thought.

The loop now joins reasoning parts on the same replace-per-step rule as text and returns them; all three loop callers — openai-compat, anthropic, sagemaker — surface it.

## The Anthropic tools block was never cached

`cacheControlOf(tool)` is read in two places and could never return anything: `MessageBuilder` marks **system messages** only (`messageBuilder.ts:643`, `:1753`), and nothing had marked a tool definition since `GenerationHandler` went away.

Tool definitions sit between the system prompt and the conversation and rarely change. With no breakpoint closing that prefix, the entire tools block was re-billed as fresh input on every turn.

The client now marks the last tool on the assembled request:
- **after** every tool mutation, including the appended `final_result` tool, so the marker really is last;
- **before** `countAnthropicCacheMarkers`, so the rolling history budget accounts for it and the four-marker ceiling still holds;
- a caller that marked a tool itself still wins.

## Red first

Both cases went into `test/continuous-test-suite-native-vendor-recovery.ts`, which already drives the native loop offline against local scripted servers — no credentials, no network.

Each asserts its **precondition before its claim**, so a pass cannot come from the request never happening:

| case | precondition | claim |
| --- | --- | --- |
| reasoning | endpoint called exactly once, and the scripted answer reached `content` | `result.reasoning` carries the vendor's reasoning |
| tool cache | a tools block actually arrived on the wire | exactly one ephemeral marker, and it is on the last tool |

**Unfixed: 4 passed, both new cases failed on their own claims. Fixed: 6/6.**

The tool-cache case first failed on its *precondition* rather than its claim — the SDK merges built-in tools with the caller's, so an exact tool count was the wrong assertion. Relaxed to a floor, which is what the test actually needs.

## Comments

The comments describing the old, broken state are corrected in the same change rather than left to drift again: `nativeToolFormat`, `anthropic/cacheControl`, `anthropicCacheBreakpoints` (both sites), `openaiChatCompletionsBase`, `baseProvider`, `neurolink`.

## Review order

This branch sits on `release`. [#1662](https://github.com/juspay/neurolink/pull/1662) edits several of the same comments to say the behaviour is **missing** — true at its merge point, and superseded here. Whichever lands second needs a small rebase on those hunks.

## Verification

`check` 0 · `lint` 0 errors · `build` 0 · `check:deps` 0 · `check:ci-scripts` 0 · `check:test-parse` 0 · `test:provider-structure` 0 · `test:model-manifests` 0 · `validate:all` 0 · **`test:vendor-recovery` 6/6** · **`test:providers-mocked` 95/95** · `test:error-classifier-contract` 0 · the **anthropic**, **vertex-claude**, **bedrock** and **aistudio** loop-characterization suites all 0 · `verify:provider-onboarding` 0 · `docs/api` regenerated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reasoning output from supported native generation providers is now included in generation results.
  * Anthropic tool requests now apply prompt-caching markers to the final tool when needed.

* **Bug Fixes**
  * Improved consistency of reasoning data across native generation paths.
  * Added safeguards to ensure Anthropic requests contain the expected prompt-caching breakpoint.
  * Added coverage to verify reasoning output and prompt-caching behavior across supported native provider flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->