### PR TITLE
feat(native-loop): reclaim context per step on the generate path

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1035,6 +1035,7 @@ console.log(result.content);
 - [SummarizeResult](type-aliases/SummarizeResult.md)
 - [DeduplicationResult](type-aliases/DeduplicationResult.md)
 - [FileSummarizationServiceOptions](type-aliases/FileSummarizationServiceOptions.md)
+- [NativeGenerateGuardConfig](type-aliases/NativeGenerateGuardConfig.md)
 - [StorageConfig](type-aliases/StorageConfig.md)
 - [ConversationMemoryConfig](type-aliases/ConversationMemoryConfig.md)
 - [SessionMemory](type-aliases/SessionMemory.md)

--- a/docs/api/type-aliases/NativeGenerateGuardConfig.md
+++ b/docs/api/type-aliases/NativeGenerateGuardConfig.md
@@ -1,0 +1,41 @@
+[**NeuroLink API Reference**](../README.md)
+
+---
+
+[NeuroLink API Reference](../README.md) / NativeGenerateGuardConfig
+
+# Type Alias: NativeGenerateGuardConfig
+
+> **NativeGenerateGuardConfig** = `object`
+
+Defined in: [types/context.ts:1032](https://github.com/juspay/neurolink/blob/release/src/lib/types/context.ts#L1032)
+
+Per-turn configuration for reclaiming a native V3 conversation.
+
+## Properties
+
+### provider
+
+> **provider**: `string`
+
+Defined in: [types/context.ts:1033](https://github.com/juspay/neurolink/blob/release/src/lib/types/context.ts#L1033)
+
+---
+
+### availableInputTokens
+
+> **availableInputTokens**: `number`
+
+Defined in: [types/context.ts:1034](https://github.com/juspay/neurolink/blob/release/src/lib/types/context.ts#L1034)
+
+---
+
+### getFixedOverheadTokens
+
+> **getFixedOverheadTokens**: () => `number`
+
+Defined in: [types/context.ts:1035](https://github.com/juspay/neurolink/blob/release/src/lib/types/context.ts#L1035)
+
+#### Returns
+
+`number`

--- a/docs/api/type-aliases/NativeGenerateLoopArgs.md
+++ b/docs/api/type-aliases/NativeGenerateLoopArgs.md
@@ -16,11 +16,54 @@ One loop serves every provider whose delegating model exposes a v3-shaped
 
 ## Properties
 
+### observeUsage?
+
+> `optional` **observeUsage?**: (`usage`) => `void`
+
+Defined in: [types/generate.ts:1785](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1785)
+
+Observed usage for calibrating the next step against the last request.
+
+#### Parameters
+
+##### usage
+
+`unknown`
+
+#### Returns
+
+`void`
+
+---
+
+### guardConversation?
+
+> `optional` **guardConversation?**: (`conversation`) => `Record`\<`string`, `unknown`\>[] \| `undefined`
+
+Defined in: [types/generate.ts:1792](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1792)
+
+Per-step context reclaim, called before every model call with the
+conversation as it now stands. Return a replacement to have the loop adopt
+it, or undefined to leave it untouched. The provider owns this because the
+reclaim has to understand its wire shape.
+
+#### Parameters
+
+##### conversation
+
+`Record`\<`string`, `unknown`\>[]
+
+#### Returns
+
+`Record`\<`string`, `unknown`\>[] \| `undefined`
+
+---
+
 ### doGenerate
 
 > **doGenerate**: (`options`) => `Promise`\<`Record`\<`string`, `unknown`\>\>
 
-Defined in: [types/generate.ts:1784](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1784)
+Defined in: [types/generate.ts:1795](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1795)
 
 #### Parameters
 
@@ -38,7 +81,7 @@ Defined in: [types/generate.ts:1784](https://github.com/juspay/neurolink/blob/re
 
 > **conversation**: `Record`\<`string`, `unknown`\>[]
 
-Defined in: [types/generate.ts:1788](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1788)
+Defined in: [types/generate.ts:1799](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1799)
 
 Conversation in the message-builder shape each doGenerate converts itself.
 
@@ -48,7 +91,7 @@ Conversation in the message-builder shape each doGenerate converts itself.
 
 > `optional` **tools?**: `Record`\<`string`, `unknown`\>[]
 
-Defined in: [types/generate.ts:1790](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1790)
+Defined in: [types/generate.ts:1801](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1801)
 
 Tool declarations in the v3 shape doGenerate already knows how to convert.
 
@@ -58,7 +101,7 @@ Tool declarations in the v3 shape doGenerate already knows how to convert.
 
 > **toolsRecord**: `Record`\<`string`, `unknown`\>
 
-Defined in: [types/generate.ts:1792](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1792)
+Defined in: [types/generate.ts:1803](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1803)
 
 Registered tools, used to execute a call the model asks for.
 
@@ -68,7 +111,7 @@ Registered tools, used to execute a call the model asks for.
 
 > `optional` **toolChoice?**: `unknown`
 
-Defined in: [types/generate.ts:1793](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1793)
+Defined in: [types/generate.ts:1804](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1804)
 
 ---
 
@@ -76,7 +119,7 @@ Defined in: [types/generate.ts:1793](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **responseFormat?**: `Record`\<`string`, `unknown`\>
 
-Defined in: [types/generate.ts:1794](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1794)
+Defined in: [types/generate.ts:1805](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1805)
 
 ---
 
@@ -84,7 +127,7 @@ Defined in: [types/generate.ts:1794](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **providerOptions?**: `Record`\<`string`, `Record`\<`string`, `unknown`\>\>
 
-Defined in: [types/generate.ts:1795](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1795)
+Defined in: [types/generate.ts:1806](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1806)
 
 ---
 
@@ -92,7 +135,7 @@ Defined in: [types/generate.ts:1795](https://github.com/juspay/neurolink/blob/re
 
 > **maxSteps**: `number`
 
-Defined in: [types/generate.ts:1796](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1796)
+Defined in: [types/generate.ts:1807](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1807)
 
 ---
 
@@ -100,7 +143,7 @@ Defined in: [types/generate.ts:1796](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **maxOutputTokens?**: `number`
 
-Defined in: [types/generate.ts:1797](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1797)
+Defined in: [types/generate.ts:1808](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1808)
 
 ---
 
@@ -108,7 +151,7 @@ Defined in: [types/generate.ts:1797](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **temperature?**: `number`
 
-Defined in: [types/generate.ts:1798](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1798)
+Defined in: [types/generate.ts:1809](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1809)
 
 ---
 
@@ -116,7 +159,7 @@ Defined in: [types/generate.ts:1798](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **abortSignal?**: `AbortSignal`
 
-Defined in: [types/generate.ts:1799](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1799)
+Defined in: [types/generate.ts:1810](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1810)
 
 ---
 
@@ -124,7 +167,7 @@ Defined in: [types/generate.ts:1799](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **toolTimeoutMs?**: `number` \| `null`
 
-Defined in: [types/generate.ts:1801](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1801)
+Defined in: [types/generate.ts:1812](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1812)
 
 Per-tool-execution cap, forwarded into `guardToolExecutor`. `null` for no bound.
 
@@ -134,7 +177,7 @@ Per-tool-execution cap, forwarded into `guardToolExecutor`. `null` for no bound.
 
 > **runStep**: (`call`) => `Promise`\<`Record`\<`string`, `unknown`\>\>
 
-Defined in: [types/generate.ts:1803](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1803)
+Defined in: [types/generate.ts:1814](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1814)
 
 Wraps one step: retry ladder plus provider error classification.
 

--- a/docs/api/type-aliases/NativeGenerateLoopResult.md
+++ b/docs/api/type-aliases/NativeGenerateLoopResult.md
@@ -8,7 +8,7 @@
 
 > **NativeGenerateLoopResult** = `object`
 
-Defined in: [types/generate.ts:1808](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1808)
+Defined in: [types/generate.ts:1819](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1819)
 
 ## Properties
 
@@ -16,7 +16,7 @@ Defined in: [types/generate.ts:1808](https://github.com/juspay/neurolink/blob/re
 
 > **text**: `string`
 
-Defined in: [types/generate.ts:1809](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1809)
+Defined in: [types/generate.ts:1820](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1820)
 
 ---
 
@@ -24,7 +24,7 @@ Defined in: [types/generate.ts:1809](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **reasoning?**: `string`
 
-Defined in: [types/generate.ts:1811](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1811)
+Defined in: [types/generate.ts:1822](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1822)
 
 Joined reasoning content parts from the final step, when the vendor sent any.
 
@@ -34,7 +34,7 @@ Joined reasoning content parts from the final step, when the vendor sent any.
 
 > **finishReason**: `string`
 
-Defined in: [types/generate.ts:1812](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1812)
+Defined in: [types/generate.ts:1823](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1823)
 
 ---
 
@@ -42,7 +42,7 @@ Defined in: [types/generate.ts:1812](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **rawFinishReason?**: `string`
 
-Defined in: [types/generate.ts:1813](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1813)
+Defined in: [types/generate.ts:1824](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1824)
 
 ---
 
@@ -50,7 +50,7 @@ Defined in: [types/generate.ts:1813](https://github.com/juspay/neurolink/blob/re
 
 > **inputTokens**: `number`
 
-Defined in: [types/generate.ts:1814](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1814)
+Defined in: [types/generate.ts:1825](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1825)
 
 ---
 
@@ -58,7 +58,7 @@ Defined in: [types/generate.ts:1814](https://github.com/juspay/neurolink/blob/re
 
 > **outputTokens**: `number`
 
-Defined in: [types/generate.ts:1815](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1815)
+Defined in: [types/generate.ts:1826](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1826)
 
 ---
 
@@ -66,7 +66,7 @@ Defined in: [types/generate.ts:1815](https://github.com/juspay/neurolink/blob/re
 
 > **cacheReadTokens**: `number`
 
-Defined in: [types/generate.ts:1816](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1816)
+Defined in: [types/generate.ts:1827](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1827)
 
 ---
 
@@ -74,7 +74,7 @@ Defined in: [types/generate.ts:1816](https://github.com/juspay/neurolink/blob/re
 
 > **cacheWriteTokens**: `number`
 
-Defined in: [types/generate.ts:1817](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1817)
+Defined in: [types/generate.ts:1828](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1828)
 
 ---
 
@@ -82,7 +82,7 @@ Defined in: [types/generate.ts:1817](https://github.com/juspay/neurolink/blob/re
 
 > **toolsUsed**: `string`[]
 
-Defined in: [types/generate.ts:1818](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1818)
+Defined in: [types/generate.ts:1829](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1829)
 
 ---
 
@@ -90,4 +90,4 @@ Defined in: [types/generate.ts:1818](https://github.com/juspay/neurolink/blob/re
 
 > **steps**: `number`
 
-Defined in: [types/generate.ts:1819](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1819)
+Defined in: [types/generate.ts:1830](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1830)

--- a/docs/api/type-aliases/SingleShotRequest.md
+++ b/docs/api/type-aliases/SingleShotRequest.md
@@ -8,7 +8,7 @@
 
 > **SingleShotRequest** = `object`
 
-Defined in: [types/generate.ts:1822](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1822)
+Defined in: [types/generate.ts:1833](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1833)
 
 ## Properties
 
@@ -16,7 +16,7 @@ Defined in: [types/generate.ts:1822](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **system?**: `string`
 
-Defined in: [types/generate.ts:1823](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1823)
+Defined in: [types/generate.ts:1834](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1834)
 
 ---
 
@@ -24,7 +24,7 @@ Defined in: [types/generate.ts:1823](https://github.com/juspay/neurolink/blob/re
 
 > **prompt**: `string`
 
-Defined in: [types/generate.ts:1824](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1824)
+Defined in: [types/generate.ts:1835](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1835)
 
 ---
 
@@ -32,7 +32,7 @@ Defined in: [types/generate.ts:1824](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **maxOutputTokens?**: `number`
 
-Defined in: [types/generate.ts:1825](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1825)
+Defined in: [types/generate.ts:1836](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1836)
 
 ---
 
@@ -40,7 +40,7 @@ Defined in: [types/generate.ts:1825](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **temperature?**: `number`
 
-Defined in: [types/generate.ts:1826](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1826)
+Defined in: [types/generate.ts:1837](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1837)
 
 ---
 
@@ -48,4 +48,4 @@ Defined in: [types/generate.ts:1826](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **abortSignal?**: `AbortSignal`
 
-Defined in: [types/generate.ts:1827](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1827)
+Defined in: [types/generate.ts:1838](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1838)

--- a/docs/api/type-aliases/SingleShotResult.md
+++ b/docs/api/type-aliases/SingleShotResult.md
@@ -8,7 +8,7 @@
 
 > **SingleShotResult** = `object`
 
-Defined in: [types/generate.ts:1830](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1830)
+Defined in: [types/generate.ts:1841](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1841)
 
 ## Properties
 
@@ -16,7 +16,7 @@ Defined in: [types/generate.ts:1830](https://github.com/juspay/neurolink/blob/re
 
 > **text**: `string`
 
-Defined in: [types/generate.ts:1831](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1831)
+Defined in: [types/generate.ts:1842](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1842)
 
 ---
 
@@ -24,7 +24,7 @@ Defined in: [types/generate.ts:1831](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **usage?**: `object`
 
-Defined in: [types/generate.ts:1832](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1832)
+Defined in: [types/generate.ts:1843](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1843)
 
 #### inputTokens?
 
@@ -44,4 +44,4 @@ Defined in: [types/generate.ts:1832](https://github.com/juspay/neurolink/blob/re
 
 > `optional` **finishReason?**: `string`
 
-Defined in: [types/generate.ts:1833](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1833)
+Defined in: [types/generate.ts:1844](https://github.com/juspay/neurolink/blob/release/src/lib/types/generate.ts#L1844)

--- a/src/lib/context/nativeGenerateGuard.ts
+++ b/src/lib/context/nativeGenerateGuard.ts
@@ -1,0 +1,234 @@
+import type {
+  LoopGuardEntry,
+  NativeGenerateGuardConfig,
+} from "../types/index.js";
+import {
+  estimateTokens,
+  TOKENS_PER_MESSAGE,
+} from "../utils/tokenEstimation.js";
+import { logger } from "../utils/logger.js";
+import { planLoopGuardReclaim } from "./loopGuardCore.js";
+import { DEFAULT_CONTEXT_GUARD_RATIO } from "../core/constants.js";
+import { generateToolOutputPreview } from "./toolOutputLimits.js";
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const partsOf = (value: unknown): Record<string, unknown>[] =>
+  Array.isArray(value) ? value.filter(isRecord) : [];
+
+const textOf = (value: unknown): string => {
+  if (typeof value === "string") {
+    return value;
+  }
+  try {
+    return JSON.stringify(value) ?? "";
+  } catch {
+    return "x".repeat(200_000);
+  }
+};
+
+const previewMessage = (
+  message: Record<string, unknown>,
+): Record<string, unknown> => ({
+  ...message,
+  // Do not stringify the whole message: call IDs, result types and metadata
+  // must survive the wire conversion. Only the result payload is shortened.
+  content: partsOf(message.content).map((part) => {
+    if (part.type !== "tool-result") {
+      return part;
+    }
+    const output = part.output;
+    const wrapped =
+      isRecord(output) &&
+      ["text", "json", "error-text", "error-json"].includes(
+        String(output.type),
+      ) &&
+      "value" in output;
+    const { preview, truncated } = generateToolOutputPreview(
+      textOf(wrapped ? output.value : output),
+      { maxBytes: 2048, maxLines: 60 },
+    );
+    if (!truncated) {
+      return part;
+    }
+    return {
+      ...part,
+      output: wrapped
+        ? {
+            ...output,
+            type: String(output.type).startsWith("error")
+              ? "error-text"
+              : "text",
+            value: preview,
+          }
+        : preview,
+    };
+  }),
+});
+
+/** V3-shape adapter for the reclaim policy shared with streaming guards. */
+export function createNativeGenerateGuard(config: NativeGenerateGuardConfig) {
+  let previousSentEstimate: number | undefined;
+  let observedPromptTokens: number | undefined;
+  const cost = (message: Record<string, unknown>): number =>
+    estimateTokens(textOf(message), config.provider) + TOKENS_PER_MESSAGE;
+
+  return {
+    observeUsage(usage: unknown): void {
+      const input = isRecord(usage) ? usage.inputTokens : undefined;
+      const total = isRecord(input) ? input.total : input;
+      observedPromptTokens =
+        typeof total === "number" && Number.isFinite(total) && total > 0
+          ? total
+          : undefined;
+    },
+    guardConversation(
+      conversation: Array<Record<string, unknown>>,
+    ): Array<Record<string, unknown>> | undefined {
+      // Policy entry zero is protected. Fold the entire initial task prefix
+      // into it so leading system messages cannot displace task protection.
+      const taskIndex = conversation.findIndex(
+        (message) => message.role === "user",
+      );
+      const prefixLength = Math.max(1, taskIndex + 1);
+      const tail = conversation.slice(prefixLength);
+      const previews = tail.map(previewMessage);
+      const entries: LoopGuardEntry[] = [
+        {
+          kind: "other",
+          tokens: conversation
+            .slice(0, prefixLength)
+            .reduce((sum, message) => sum + cost(message), 0),
+        },
+        ...tail.map((message, index): LoopGuardEntry => {
+          const parts = partsOf(message.content);
+          if (
+            message.role === "assistant" &&
+            parts.some((part) => part.type === "tool-call")
+          ) {
+            return { kind: "toolCall", tokens: cost(message) };
+          }
+          if (
+            message.role === "tool" &&
+            parts.some((part) => part.type === "tool-result")
+          ) {
+            return {
+              kind: "toolResult",
+              tokens: cost(message),
+              previewTokens: cost(previews[index]),
+            };
+          }
+          return { kind: "other", tokens: cost(message) };
+        }),
+      ];
+      const overhead = config.getFixedOverheadTokens();
+      const calibration =
+        observedPromptTokens && previousSentEstimate
+          ? Math.min(
+              3,
+              Math.max(1, observedPromptTokens / previousSentEstimate),
+            )
+          : 1;
+      const plan = planLoopGuardReclaim(entries, {
+        availableInputTokens: config.availableInputTokens,
+        fixedOverheadTokens: overhead,
+        calibration,
+      });
+      // The policy fires at a RATIO of the window, not at the window itself, so
+      // every number below is measured against that same threshold. Comparing
+      // against the raw budget leaves a ~15% band in which the guard has
+      // already crossed its reclaim point while the log still reads "under
+      // budget" with positive headroom — defeating the purpose of making the
+      // threshold measurable, since a probe sizing a payload from that headroom
+      // would aim past the point it meant to cross.
+      const reclaimThresholdTokens = Math.floor(
+        (config.availableInputTokens * DEFAULT_CONTEXT_GUARD_RATIO) /
+          (calibration > 0 ? calibration : 1),
+      );
+      const estimatedBeforeTokens =
+        overhead + entries.reduce((sum, entry) => sum + entry.tokens, 0);
+      if (!plan.fire) {
+        previousSentEstimate = estimatedBeforeTokens;
+        // Staying under budget is the common case and must not be noisy, but
+        // silence here is unfalsifiable: no line at all reads the same whether
+        // the conversation fit, the guard was never installed, or this hook was
+        // never called. Two live attempts to demonstrate the reclaim against a
+        // real vendor produced nothing and could not distinguish those, because
+        // the budget is not observable from outside the process. Emitting the
+        // budget and the headroom at debug makes the threshold measurable, so a
+        // probe can size a payload to cross it instead of guessing.
+        // Two very different situations reach this branch and must not share a
+        // message. Fitting is routine and belongs at debug. Being over budget
+        // with nothing reclaimable is neither: the planner only touches entries
+        // strictly between the task and the newest
+        // DEFAULT_LOOP_GUARD_PROTECTED_TAIL, so a conversation whose oversize
+        // content sits inside that protected tail — one large tool result, the
+        // common case — yields an empty plan, and the request is sent over the
+        // window anyway to be rejected or silently truncated by the vendor.
+        // Observed live against deepseek: 186,847 estimated against a 62,500
+        // budget, empty plan, no signal of any kind before this warning.
+        if (estimatedBeforeTokens > reclaimThresholdTokens) {
+          logger.warn(
+            "[NativeGenerateGuard] Over threshold, nothing reclaimable",
+            {
+              provider: config.provider,
+              availableInputTokens: config.availableInputTokens,
+              reclaimThresholdTokens,
+              estimatedPromptTokens: estimatedBeforeTokens,
+              overThresholdByTokens:
+                estimatedBeforeTokens - reclaimThresholdTokens,
+              calibration,
+            },
+          );
+        } else {
+          logger.debug("[NativeGenerateGuard] Under threshold", {
+            provider: config.provider,
+            availableInputTokens: config.availableInputTokens,
+            reclaimThresholdTokens,
+            estimatedPromptTokens: estimatedBeforeTokens,
+            headroomToThresholdTokens:
+              reclaimThresholdTokens - estimatedBeforeTokens,
+            calibration,
+          });
+        }
+        return undefined;
+      }
+      const drop = new Set(plan.drop);
+      const truncate = new Set(plan.truncate);
+      const result = [...conversation.slice(0, prefixLength)];
+      let noted = false;
+      tail.forEach((message, index) => {
+        const entry = index + 1;
+        if (drop.has(entry)) {
+          if (!noted) {
+            result.push({
+              role: "user",
+              content:
+                "[Earlier tool exchanges were removed to fit the context window.]",
+            });
+          }
+          noted = true;
+        } else {
+          result.push(truncate.has(entry) ? previews[index] : message);
+        }
+      });
+      previousSentEstimate =
+        overhead + result.reduce((sum, message) => sum + cost(message), 0);
+      logger.info("[NativeGenerateGuard] Reclaimed context", {
+        provider: config.provider,
+        // The budget and both estimates travel with the event so a reader can
+        // see WHY it fired and by how much it overshot, rather than only that
+        // it did.
+        availableInputTokens: config.availableInputTokens,
+        reclaimThresholdTokens,
+        estimatedBeforeTokens,
+        estimatedAfterTokens: previousSentEstimate,
+        truncated: plan.truncate.length,
+        dropped: plan.drop.length,
+        calibration,
+      });
+      return result;
+    },
+  };
+}

--- a/src/lib/core/nativeGenerateLoop.ts
+++ b/src/lib/core/nativeGenerateLoop.ts
@@ -161,6 +161,20 @@ export async function runNativeGenerateLoop(
 
   for (let step = 0; step < args.maxSteps; step++) {
     steps = step + 1;
+    // Per-step context reclaim. The pre-dispatch budget check runs ONCE and
+    // never sees the assistant turns and tool results this loop appends, which
+    // is how a long agentic run overflows the model window mid-loop and loses
+    // every completed step to a provider 400. The streaming paths have guarded
+    // this for a while; generate() did not, so the identical turn reclaimed on
+    // stream() and overflowed on generate().
+    //
+    // The provider supplies the guard because only it knows its wire shape.
+    // Returning undefined leaves the conversation byte-identical, so a turn
+    // that fits never pays a prompt-cache invalidation.
+    const guarded = args.guardConversation?.(args.conversation);
+    if (guarded) {
+      args.conversation.splice(0, args.conversation.length, ...guarded);
+    }
     const runThisStep = () =>
       args.runStep(() =>
         args.doGenerate({
@@ -219,6 +233,8 @@ export async function runNativeGenerateLoop(
       throw stepError;
     }
     reaskPending = false;
+
+    args.observeUsage?.(res.usage);
 
     const parts = asParts(res.content);
     // Each step REPLACES the text rather than appending: the final step's

--- a/src/lib/providers/openaiChatCompletionsBase.ts
+++ b/src/lib/providers/openaiChatCompletionsBase.ts
@@ -28,6 +28,11 @@ import {
 } from "../constants/contextWindows.js";
 import { guardOpenAICompatConversation } from "../context/openaiCompatLoopGuard.js";
 import {
+  estimateTokens,
+  serializeForEstimate,
+} from "../utils/tokenEstimation.js";
+import { createNativeGenerateGuard } from "../context/nativeGenerateGuard.js";
+import {
   isContextOverflowError,
   parseProviderOverflowDetails,
 } from "../context/errorDetection.js";
@@ -1189,6 +1194,27 @@ export abstract class OpenAIChatCompletionsProvider extends BaseProvider {
       runNativeGenerateLoop(
         {
           doGenerate,
+          ...createNativeGenerateGuard({
+            provider: this.providerName,
+            availableInputTokens: getAvailableInputTokens(
+              this.providerName,
+              modelId,
+              options.maxTokens ?? undefined,
+            ),
+            // Runs on every step of the generate loop, so a cyclic or
+            // oversized tool schema must not throw the turn away. Shares the
+            // estimator's own serializer: its fallback over-reports, which
+            // makes the guard fire rather than silently size the overhead at
+            // nothing.
+            getFixedOverheadTokens: () =>
+              estimateTokens(
+                serializeForEstimate({
+                  tools: v3Tools,
+                  responseFormat: format,
+                }),
+                this.providerName,
+              ),
+          }),
           conversation: conv,
           ...(v3Tools ? { tools: v3Tools } : {}),
           toolsRecord,

--- a/src/lib/types/context.ts
+++ b/src/lib/types/context.ts
@@ -1027,3 +1027,10 @@ export type FileSummarizationServiceOptions = {
   provider?: string;
   model?: string;
 };
+
+/** Per-turn configuration for reclaiming a native V3 conversation. */
+export type NativeGenerateGuardConfig = {
+  provider: string;
+  availableInputTokens: number;
+  getFixedOverheadTokens: () => number;
+};

--- a/src/lib/types/generate.ts
+++ b/src/lib/types/generate.ts
@@ -1781,6 +1781,17 @@ export type GenerateOptionsNormalized = GenerateOptions & {
  * `doGenerate`; the provider supplies the wire details.
  */
 export type NativeGenerateLoopArgs = {
+  /** Observed usage for calibrating the next step against the last request. */
+  observeUsage?: (usage: unknown) => void;
+  /**
+   * Per-step context reclaim, called before every model call with the
+   * conversation as it now stands. Return a replacement to have the loop adopt
+   * it, or undefined to leave it untouched. The provider owns this because the
+   * reclaim has to understand its wire shape.
+   */
+  guardConversation?: (
+    conversation: Array<Record<string, unknown>>,
+  ) => Array<Record<string, unknown>> | undefined;
   doGenerate: (
     options: Record<string, unknown>,
   ) => Promise<Record<string, unknown>>;

--- a/src/lib/utils/tokenEstimation.ts
+++ b/src/lib/utils/tokenEstimation.ts
@@ -114,7 +114,12 @@ export function estimateTokens(
  * charged at the fallback size rather than aborting the estimate (and with it
  * the whole turn).
  */
-function serializeForEstimate(value: unknown): string {
+/**
+ * Serialize a value for token estimation. The fallback is deliberately huge:
+ * an estimator that cannot measure a value must over-report, so a budget guard
+ * fires rather than waving through content it failed to size.
+ */
+export function serializeForEstimate(value: unknown): string {
   if (typeof value === "string") {
     return value;
   }

--- a/test/continuous-test-suite-native-vendor-recovery.ts
+++ b/test/continuous-test-suite-native-vendor-recovery.ts
@@ -692,5 +692,208 @@ await test("stream preserves an explicit caller cache marker without adding anot
     }
   }
 });
+// ---------------------------------------------------------------------------
+// Per-step context reclaim on the GENERATE path.
+//
+// Both native loop guards — guardOpenAICompatConversation and
+// planAnthropicLoopReclaim — were wired into executeStream only, so a long
+// agentic generate() walked into a provider context-overflow with no reclaim,
+// while the identical stream() turn reclaimed. Nothing covered either guard.
+// ---------------------------------------------------------------------------
+
+await test("generate() reclaims context when a tool loop outgrows the window", async () => {
+  const STEPS = 6;
+  // Head/tail preview keeps the ends and drops the middle, so a sentinel in
+  // the middle is exactly what disappears when an output is truncated.
+  const blob = (i: number): string =>
+    `${"A".repeat(50_000)}SENTINEL_${i}${"B".repeat(50_000)}`;
+
+  const script = [];
+  for (let i = 0; i < STEPS; i++) {
+    script.push(
+      chatCompletion({
+        finishReason: "tool_calls",
+        toolCalls: [
+          {
+            id: `call_${i}`,
+            type: "function",
+            function: { name: "big_tool", arguments: JSON.stringify({ i }) },
+          },
+        ],
+      }),
+    );
+  }
+  script.push(
+    chatCompletion({ content: "final answer", finishReason: "stop" }),
+  );
+
+  let calls = 0;
+  const server = await startScriptedChatServer(script);
+  const sdk = new NeuroLink();
+  try {
+    const result = await sdk.generate({
+      input: { text: "call the tool repeatedly then answer" },
+      provider: "openai",
+      model: "gpt-4o-mini",
+      disableInternalFallback: true,
+      maxSteps: STEPS + 2,
+      credentials: credentialsFor(server.baseURL),
+      tools: {
+        big_tool: tool({
+          description: "Returns a very large payload",
+          inputSchema: z.object({ i: z.number() }),
+          execute: async () => blob(calls++),
+        }),
+      },
+    });
+
+    // Preconditions: the loop must actually have run every step, or there is
+    // no oversized history for a guard to reclaim and the claim proves nothing.
+    if (server.requestCount() < STEPS + 1) {
+      throw new Error(
+        `precondition: loop stopped early at ${server.requestCount()} requests`,
+      );
+    }
+    if (calls < STEPS) {
+      throw new Error(
+        `precondition: tool ran ${calls} times, expected ${STEPS}`,
+      );
+    }
+    if (result.content !== "final answer") {
+      throw new Error("precondition: the final answer did not reach content");
+    }
+
+    const bodies = server.getAllRequestBodies();
+    const last = bodies[bodies.length - 1] ?? "";
+    // The newest tool output rides inside the protected tail and must survive
+    // untouched — without this, "reclaimed" could just mean "dropped it all".
+    if (!last.includes(`SENTINEL_${STEPS - 1}`)) {
+      throw new Error(
+        "the most recent tool output was reclaimed, but must not be",
+      );
+    }
+    // The oldest output sits well outside the protected tail. If no reclaim
+    // happened it is still there in full.
+    if (last.includes("SENTINEL_0")) {
+      throw new Error(
+        "the oldest tool output was still sent in full — no context reclaim ran on the generate path",
+      );
+    }
+  } finally {
+    await sdk.shutdown();
+    await server.close();
+  }
+});
+
+for (const calibrated of [false, true]) {
+  await test(`generate reclaim preserves tool pairs (${calibrated ? "calibrated usage" : "batch dropping"})`, async () => {
+    const count = 8;
+    const padding = "x".repeat(calibrated ? 24_000 : 75_000);
+    const replies = Array.from({ length: count }, (_, i) => ({
+      ...chatCompletion({
+        finishReason: "tool_calls",
+        toolCalls: [
+          {
+            id: `batch_${i}`,
+            type: "function",
+            function: {
+              name: "record_batch",
+              arguments: JSON.stringify({ i, padding }),
+            },
+          },
+        ],
+      }),
+      usage: {
+        prompt_tokens: calibrated ? 100_000 : 1,
+        completion_tokens: 1,
+        total_tokens: calibrated ? 100_001 : 2,
+      },
+    }));
+    const server = await startScriptedChatServer([
+      ...replies,
+      chatCompletion({ content: "paired answer" }),
+    ]);
+    const sdk = new NeuroLink();
+    let executions = 0;
+    try {
+      const result = await sdk.generate({
+        input: { text: "TASK_MUST_SURVIVE" },
+        provider: "openai",
+        model: "gpt-4o-mini",
+        maxSteps: count + 1,
+        maxTokens: 1024,
+        disableInternalFallback: true,
+        credentials: credentialsFor(server.baseURL),
+        tools: {
+          record_batch: tool({
+            description: "Return a small result",
+            inputSchema: z.object({ i: z.number(), padding: z.string() }),
+            execute: async ({ i }) => {
+              executions++;
+              return `result_${i}`;
+            },
+          }),
+        },
+      });
+      if (
+        executions !== count ||
+        server.requestCount() !== count + 1 ||
+        result.content !== "paired answer"
+      ) {
+        throw new Error("precondition: all scripted batch steps must finish");
+      }
+      const requests = server.getAllRequestBodies().map(
+        (body) =>
+          JSON.parse(body) as {
+            messages: Array<{
+              role: string;
+              content?: unknown;
+              tool_call_id?: string;
+              tool_calls?: Array<{ id: string }>;
+            }>;
+          },
+      );
+      if (!JSON.stringify(requests[1]).includes("batch_0")) {
+        throw new Error("precondition: original batch never reached the wire");
+      }
+      for (const request of requests) {
+        const pending = new Set<string>();
+        for (const message of request.messages) {
+          if (message.role === "tool") {
+            if (
+              !message.tool_call_id ||
+              !pending.delete(message.tool_call_id)
+            ) {
+              throw new Error("reclaim emitted an orphan tool result");
+            }
+          } else {
+            if (pending.size) {
+              throw new Error("reclaim emitted an unanswered tool call");
+            }
+            for (const call of message.tool_calls ?? []) {
+              pending.add(call.id);
+            }
+          }
+        }
+        if (pending.size) {
+          throw new Error("request ends with unanswered tool calls");
+        }
+      }
+      const last = JSON.stringify(requests.at(-1));
+      if (last.includes("batch_0")) {
+        throw new Error("old batch was not reclaimed");
+      }
+      if (
+        !last.includes(`batch_${count - 1}`) ||
+        !last.includes("TASK_MUST_SURVIVE")
+      ) {
+        throw new Error("reclaim removed the task or protected tail");
+      }
+    } finally {
+      await sdk.shutdown();
+      await server.close();
+    }
+  });
+}
 
 await runSuite();


### PR DESCRIPTION
## What

Add per-step context reclaim to the native OpenAI-compatible `generate()` loop. Streaming already had reclaim; generation did not.

## Review fixes

The initial implementation passed V3 conversation messages to the OpenAI **wire** adapter. That was incorrect: assistant calls are `content` parts here, not `tool_calls`, and replacing a whole result message with a string loses its call IDs. This revision uses `nativeGenerateGuard.ts`, a V3-specific adapter over the existing `loopGuardCore` policy.

- Preview only tool-result payloads, preserving IDs, output envelopes, and other parts.
- Drop complete call/result batches; protect the initial task prefix and newest four entries.
- Observe `usage.inputTokens.total` (also accept numeric usage) to calibrate the next step against the preceding request estimate.
- Resolve tool/schema overhead per request. Return `undefined` and preserve conversation bytes when no reclaim is needed.
- Reuse the same adapter for the separate Anthropic generate-guard PR; no provider-wire casts.

## Proof

The public SDK suite drives local HTTP endpoints and inspects **every outbound request**, not merely the final response.

Before correction, the new batch-dropping test failed with `reclaim emitted an unanswered tool call`, and the calibration test failed with `old batch was not reclaimed`. After correction, `test:vendor-recovery` passes **11/11** (this line previously said 9/9, which was stale — the suite gained three cases in this PR; re-run and corrected 2026-09-11). The original large-output test remains, alongside whole-batch pairing and shaped-usage coverage.

No live vendor endpoint was used. Local typecheck, lint, build, and test-script typechecks are run before push; GitHub required checks remain the merge gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Native generation now automatically reclaims conversation context when approaching input limits.
  - Older or oversized tool results may be shortened or removed while preserving recent context, tool-call pairings, and task instructions.
  - Context handling adapts based on observed model usage for more reliable multi-step tool workflows.
  - Tool execution timeouts can now be disabled when needed.

- **Bug Fixes**
  - Improved reliability for extended generation loops, reducing failures caused by oversized conversation history.

- **Documentation**
  - Updated API documentation to describe the new context-management configuration and timeout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
