### PR TITLE
fix(sagemaker): adapt legacy results for the native generate loop

### DIFF
--- a/src/lib/providers/amazonSagemaker.ts
+++ b/src/lib/providers/amazonSagemaker.ts
@@ -209,7 +209,71 @@ export class AmazonSageMakerProvider extends BaseProvider {
         new Error("sagemaker: model handle exposes no doGenerate()"),
       );
     }
-    const doGenerate = model.doGenerate.bind(model);
+    const doGenerate = async (
+      call: Record<string, unknown>,
+    ): Promise<Record<string, unknown>> => {
+      const format = call.responseFormat as Record<string, unknown> | undefined;
+      const result = await model.doGenerate({
+        ...call,
+        ...(call.maxOutputTokens !== undefined
+          ? { maxTokens: call.maxOutputTokens }
+          : {}),
+        ...(format?.type === "json"
+          ? {
+              responseFormat: format.schema
+                ? {
+                    type: "json_schema",
+                    json_schema: { name: "response", schema: format.schema },
+                  }
+                : { type: "json_object" },
+            }
+          : {}),
+      });
+      // SageMaker's low-level model retains its legacy result for streaming
+      // and direct consumers. The shared loop consumes V3 content and usage.
+      if (Array.isArray(result.content)) {
+        return result;
+      }
+      const content: Array<Record<string, unknown>> = [];
+      if (typeof result.text === "string" && result.text) {
+        content.push({ type: "text", text: result.text });
+      }
+      if (typeof result.reasoning === "string" && result.reasoning) {
+        content.push({ type: "reasoning", text: result.reasoning });
+      }
+      for (const call of Array.isArray(result.toolCalls)
+        ? result.toolCalls
+        : []) {
+        if (typeof call !== "object" || call === null) {
+          continue;
+        }
+        const item = call as Record<string, unknown>;
+        const fn = item.function as Record<string, unknown> | undefined;
+        if (typeof item.id === "string" && typeof fn?.name === "string") {
+          content.push({
+            type: "tool-call",
+            toolCallId: item.id,
+            toolName: fn.name,
+            input: fn.arguments ?? "{}",
+          });
+        }
+      }
+      const usage = result.usage as Record<string, unknown> | undefined;
+      return {
+        ...result,
+        content,
+        usage: {
+          inputTokens: {
+            total:
+              typeof usage?.inputTokens === "number" ? usage.inputTokens : 0,
+          },
+          outputTokens: {
+            total:
+              typeof usage?.outputTokens === "number" ? usage.outputTokens : 0,
+          },
+        },
+      };
+    };
 
     const shouldUseTools = !options.disableTools && this.supportsTools();
     const toolsRecord = shouldUseTools

--- a/src/lib/providers/sagemaker/language-model.ts
+++ b/src/lib/providers/sagemaker/language-model.ts
@@ -588,8 +588,8 @@ export class SageMakerLanguageModel implements SageMakerAsLanguageModel {
         ...(options.maxTokens !== undefined
           ? { max_new_tokens: options.maxTokens }
           : {}),
-        temperature: options.temperature || 0.7,
-        top_p: options.topP || 0.9,
+        temperature: options.temperature ?? 0.7,
+        top_p: options.topP ?? 0.9,
         stop: options.stopSequences || [],
       },
     };
@@ -804,8 +804,13 @@ export class SageMakerLanguageModel implements SageMakerAsLanguageModel {
     // Handle response with tool calls
     if (responseBody.choices && Array.isArray(responseBody.choices)) {
       const choice = responseBody.choices[0];
-      if (choice?.message?.content) {
+      if (typeof choice?.message?.content === "string") {
         return choice.message.content;
+      }
+      // A tool-only assistant turn has no text. Serializing the entire
+      // endpoint response here would replay its envelope as assistant prose.
+      if (choice?.message?.tool_calls?.length) {
+        return "";
       }
     }
 

--- a/test/continuous-test-suite-sagemaker-streaming.ts
+++ b/test/continuous-test-suite-sagemaker-streaming.ts
@@ -23,6 +23,7 @@ import "dotenv/config";
  */
 
 import { createServer, type Server } from "node:http";
+import { z } from "zod";
 import { assert, defineSuite } from "./helpers/harness.js";
 import { assertDistFresh } from "./helpers/distFreshness.js";
 
@@ -30,7 +31,7 @@ assertDistFresh();
 
 const { test, runSuite } = defineSuite("SageMaker streaming");
 
-const { NeuroLink } = await import("../dist/index.js");
+const { NeuroLink, tool } = await import("../dist/index.js");
 
 type StandIn = {
   requests: number;
@@ -40,15 +41,22 @@ type StandIn = {
 
 /** Local stand-in for the SageMaker runtime endpoint. */
 async function startStandIn(
-  respond: (requestIndex: number) => { status: number; body: string },
+  respond: (
+    requestIndex: number,
+    requestBody: string,
+  ) => { status: number; body: string },
 ): Promise<StandIn> {
   let requests = 0;
   const server: Server = createServer((req, res) => {
     const index = requests;
     requests++;
-    req.resume();
+    let requestBody = "";
+    req.setEncoding("utf8");
+    req.on("data", (chunk: string) => {
+      requestBody += chunk;
+    });
     req.on("end", () => {
-      const { status, body } = respond(index);
+      const { status, body } = respond(index, requestBody);
       res.writeHead(status, { "content-type": "application/json" });
       res.end(body);
     });
@@ -432,6 +440,183 @@ await test("an aborted SageMaker turn ends promptly and still reads as an abort"
     } else {
       process.env.NEUROLINK_SKIP_MCP = priorSkipMcp;
     }
+    restoreEnv();
+    await server.close();
+  }
+});
+
+await test("generate preserves SageMaker text, endpoint usage and sampling options", async () => {
+  let sent: Record<string, unknown> = {};
+  const server = await startStandIn((_, raw) => {
+    sent = JSON.parse(raw);
+    return {
+      status: 200,
+      body: JSON.stringify({
+        generated_text: "SAGEMAKER_TEXT",
+        usage: { prompt_tokens: 17, completion_tokens: 9, total_tokens: 26 },
+      }),
+    };
+  });
+  const restoreEnv = withoutAwsEnv();
+  const sdk = new NeuroLink();
+  try {
+    const result = await sdk.generate({
+      input: { text: "hello" },
+      provider: "sagemaker",
+      model: "test-endpoint",
+      disableTools: true,
+      disableInternalFallback: true,
+      maxTokens: 37,
+      temperature: 0,
+      credentials: credentialsFor(server.port),
+    });
+    assert(
+      server.requests > 0,
+      "precondition: request never reached SageMaker endpoint",
+    );
+    assert(
+      result.content === "SAGEMAKER_TEXT",
+      "SageMaker text did not survive the native loop",
+    );
+    assert(
+      result.usage?.input === 17 && result.usage?.output === 9,
+      "endpoint token counts did not survive the native loop",
+    );
+    const parameters = sent.parameters as Record<string, unknown>;
+    assert(
+      parameters.max_new_tokens === 37 && parameters.temperature === 0,
+      "explicit sampling options did not reach endpoint",
+    );
+  } finally {
+    await sdk.shutdown();
+    restoreEnv();
+    await server.close();
+  }
+});
+
+await test("generate executes SageMaker tool calls and replays their result", async () => {
+  let executed = 0;
+  let replayed = false;
+  let leakedEnvelope = false;
+  const server = await startStandIn((i, raw) => {
+    if (i === 0) {
+      return {
+        status: 200,
+        body: JSON.stringify({
+          choices: [
+            {
+              message: {
+                role: "assistant",
+                content: null,
+                tool_calls: [
+                  {
+                    id: "sagemaker_call",
+                    type: "function",
+                    function: { name: "lookup", arguments: '{"key":"item"}' },
+                  },
+                ],
+              },
+              finish_reason: "tool_calls",
+            },
+          ],
+          usage: { prompt_tokens: 7, completion_tokens: 3 },
+        }),
+      };
+    }
+    replayed =
+      raw.includes("SAGEMAKER_TOOL_RESULT") && raw.includes("sagemaker_call");
+    leakedEnvelope = raw.includes("choices");
+    return {
+      status: 200,
+      body: JSON.stringify({
+        generated_text: "SAGEMAKER_DONE",
+        usage: { prompt_tokens: 11, completion_tokens: 5 },
+      }),
+    };
+  });
+  const restoreEnv = withoutAwsEnv();
+  const sdk = new NeuroLink();
+  try {
+    const result = await sdk.generate({
+      input: { text: "lookup item" },
+      provider: "sagemaker",
+      model: "test-endpoint",
+      disableInternalFallback: true,
+      maxSteps: 3,
+      credentials: credentialsFor(server.port),
+      tools: {
+        lookup: tool({
+          description: "Lookup item",
+          inputSchema: z.object({ key: z.string() }),
+          execute: async ({ key }) => {
+            assert(key === "item", "tool arguments were corrupted");
+            executed++;
+            return "SAGEMAKER_TOOL_RESULT";
+          },
+        }),
+      },
+    });
+    assert(server.requests > 0, "precondition: endpoint never ran");
+    assert(
+      executed === 1 && server.requests === 2,
+      "SageMaker tool call was not executed exactly once",
+    );
+    assert(
+      replayed,
+      "SageMaker next request lost the tool result or call identity",
+    );
+    assert(
+      !leakedEnvelope,
+      "raw endpoint envelope leaked into the assistant replay",
+    );
+    assert(
+      result.content === "SAGEMAKER_DONE",
+      "tool loop final answer was lost",
+    );
+    assert(
+      result.usage?.input === 18 && result.usage?.output === 8,
+      "multi-step usage was not accumulated",
+    );
+  } finally {
+    await sdk.shutdown();
+    restoreEnv();
+    await server.close();
+  }
+});
+
+await test("generate forwards the SageMaker JSON schema and returns structured data", async () => {
+  let format: unknown;
+  const server = await startStandIn((_, raw) => {
+    format = (JSON.parse(raw) as { response_format?: unknown }).response_format;
+    return {
+      status: 200,
+      body: JSON.stringify({ generated_text: '{"answer":42}' }),
+    };
+  });
+  const restoreEnv = withoutAwsEnv();
+  const sdk = new NeuroLink();
+  try {
+    const schema = z.object({ answer: z.number() });
+    const result = await sdk.generate({
+      input: { text: "return JSON" },
+      provider: "sagemaker",
+      model: "test-endpoint",
+      disableTools: true,
+      disableInternalFallback: true,
+      credentials: credentialsFor(server.port),
+      schema,
+    });
+    assert(server.requests > 0, "precondition: endpoint never ran");
+    assert(
+      (format as { type?: string })?.type === "json_schema",
+      "JSON schema was not sent to SageMaker",
+    );
+    assert(
+      schema.safeParse(result.structuredData).success,
+      "SageMaker structured result was lost",
+    );
+  } finally {
+    await sdk.shutdown();
     restoreEnv();
     await server.close();
   }


### PR DESCRIPTION
## What

Adapt SageMaker's legacy `doGenerate()` result at the provider's native-loop boundary. The shared loop expects V3 `content` parts and shaped token usage; SageMaker returned top-level `text`, `toolCalls`, and numeric usage. As a result, text disappeared and tools never executed.

The adapter preserves text, reasoning strings, tool-call IDs/arguments, and endpoint usage. It translates `maxOutputTokens` and JSON schema options to SageMaker's existing request contract, and preserves explicit zero sampling values. The low-level result and existing streaming path are unchanged.

## Regression proof

Tests construct `NeuroLink` from `dist/index.js`, use the real AWS client with `credentials.sagemaker.endpoint` pointing at a local HTTP server, and assert that the endpoint actually received requests.

New cases were red before the fix:
- Returned text and numeric usage survive; max tokens and temperature zero reach the endpoint.
- Tool calls execute once, their IDs/results appear in the next request, and usage accumulates across steps.
- The requested JSON schema reaches the endpoint and parsed `structuredData` reaches the caller.

After the fix: **9/9**, including the six existing streaming cases. No live AWS endpoint was used; this proves the SDK boundary and HTTP transport contract, not compatibility with every deployed model container.

## Review follow-up

The tool-only response extractor previously fell back to serializing the whole endpoint envelope as assistant text. The extractor now returns an empty text for tool-only replies while retaining genuine text returned alongside tool calls. The regression checks the next request for absence of the raw `choices` envelope in addition to tool execution, call-ID/result replay, and token accounting. The strengthened assertion failed before this fix and the suite passes 9/9 after it.

All remaining merges are reserved to the repository owner.
