### PR TITLE
fix(sdk): forward thinkingConfig through the generate option allowlist

### DIFF
--- a/docs/api/classes/NeuroLink.md
+++ b/docs/api/classes/NeuroLink.md
@@ -469,7 +469,7 @@ Gracefully shutdown NeuroLink and all MCP connections
 
 > **generateText**(`options`): `Promise`\<[`TextGenerationResult`](../type-aliases/TextGenerationResult.md)\>
 
-Defined in: [neurolink.ts:6509](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L6509)
+Defined in: [neurolink.ts:6525](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L6525)
 
 BACKWARD COMPATIBILITY: Legacy generateText method
 Internally calls generate() and converts result format
@@ -490,7 +490,7 @@ Internally calls generate() and converts result format
 
 > **streamText**(`prompt`, `options?`): `Promise`\<`AsyncIterable`\<`string`, `any`, `any`\>\>
 
-Defined in: [neurolink.ts:9006](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L9006)
+Defined in: [neurolink.ts:9022](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L9022)
 
 BACKWARD COMPATIBILITY: Legacy streamText method
 Internally calls stream() and converts result format
@@ -515,7 +515,7 @@ Internally calls stream() and converts result format
 
 > **stream**(`options`): `Promise`\<[`StreamResult`](../type-aliases/StreamResult.md)\>
 
-Defined in: [neurolink.ts:9089](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L9089)
+Defined in: [neurolink.ts:9105](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L9105)
 
 Stream AI-generated content in real-time using the best available provider.
 This method provides real-time streaming of AI responses with full MCP tool integration.
@@ -588,7 +588,7 @@ When conversation memory operations fail (if enabled)
 
 > **setToolRoutingServers**(`servers`): `void`
 
-Defined in: [neurolink.ts:9981](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L9981)
+Defined in: [neurolink.ts:9997](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L9997)
 
 Supplies (or replaces) the pre-call tool routing server catalog.
 
@@ -613,7 +613,7 @@ alone does not activate it.
 
 > **getKnowledgeStatus**(): [`KnowledgeEngineStatus`](../type-aliases/KnowledgeEngineStatus.md) \| `null`
 
-Defined in: [neurolink.ts:9999](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L9999)
+Defined in: [neurolink.ts:10015](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L10015)
 
 Knowledge-grounding engine health (null when it was not configured).
 
@@ -627,7 +627,7 @@ Knowledge-grounding engine health (null when it was not configured).
 
 > **getEventEmitter**(): `TypedEventEmitter`\<[`NeuroLinkEvents`](../type-aliases/NeuroLinkEvents.md)\>
 
-Defined in: [neurolink.ts:12414](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12414)
+Defined in: [neurolink.ts:12430](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12430)
 
 Get the EventEmitter instance to listen to NeuroLink events for real-time monitoring and debugging.
 This method provides access to the internal event system that emits events during AI generation,
@@ -833,7 +833,7 @@ This method does not throw errors as it returns the internal EventEmitter
 
 > **hasPendingHITLConfirmation**(`confirmationId`): `boolean`
 
-Defined in: [neurolink.ts:12454](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12454)
+Defined in: [neurolink.ts:12470](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12470)
 
 Whether a HITL confirmation is still awaiting a response on THIS instance.
 
@@ -888,7 +888,7 @@ neurolink.getEventEmitter().emit("hitl:confirmation-response", { ... });
 
 > **getToolDedupConfig**(): [`ToolDedupConfig`](../type-aliases/ToolDedupConfig.md) \| `undefined`
 
-Defined in: [neurolink.ts:12470](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12470)
+Defined in: [neurolink.ts:12486](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12486)
 
 Returns the instance-level tool-dedup configuration, or `undefined` when
 toolDedup was not provided at construction time.
@@ -911,7 +911,7 @@ parameter through the full call stack.
 
 > **getToolsConfig**(): [`ToolConfig`](../type-aliases/ToolConfig.md) \| `undefined`
 
-Defined in: [neurolink.ts:12481](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12481)
+Defined in: [neurolink.ts:12497](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12497)
 
 Returns the instance-level `tools` config (master switch, include/exclude
 lists, discovery mode), or `undefined` when not provided at construction.
@@ -929,7 +929,7 @@ instance policy with per-call options on every generate/stream call.
 
 > **getDiscoveryPins**(`sessionKey`): `ReadonlySet`\<`string`\>
 
-Defined in: [neurolink.ts:12492](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12492)
+Defined in: [neurolink.ts:12508](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12508)
 
 Tools discovered via `search_tools` for a session (`tools.discovery`
 mode). Pinned tools are sent in full on every subsequent call of that
@@ -953,7 +953,7 @@ are never the ones evicted at the session cap.
 
 > **pinDiscoveredTools**(`sessionKey`, `toolNames`): `void`
 
-Defined in: [neurolink.ts:12509](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12509)
+Defined in: [neurolink.ts:12525](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12525)
 
 Pin discovered tools to a session (called by the `search_tools`
 meta-tool on hydration). Append-only within a session; the map is
@@ -979,7 +979,7 @@ bounded by evicting the least-recently-used session past 1000 sessions.
 
 > **checkCredentials**(`input`): `Promise`\<\{ `provider`: `string`; `status`: `"network"` \| `"expired"` \| `"unknown"` \| `"ok"` \| `"missing"` \| `"denied"`; `detail`: `string`; \}\>
 
-Defined in: [neurolink.ts:12554](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12554)
+Defined in: [neurolink.ts:12570](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12570)
 
 Curator P1-1: synchronous credential health check for a single provider.
 
@@ -1031,7 +1031,7 @@ if (health.status !== "ok") {
 
 > **emitToolStart**(`toolName`, `input`, `startTime?`): `string`
 
-Defined in: [neurolink.ts:12633](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12633)
+Defined in: [neurolink.ts:12649](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12649)
 
 Emit tool start event with execution tracking
 
@@ -1067,7 +1067,7 @@ executionId for tracking this specific execution
 
 > **emitToolEnd**(`toolName`, `result?`, `error?`, `startTime?`, `endTime?`, `executionId?`): `void`
 
-Defined in: [neurolink.ts:12684](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12684)
+Defined in: [neurolink.ts:12700](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12700)
 
 Emit tool end event with execution summary
 
@@ -1119,7 +1119,7 @@ Optional execution ID for tracking
 
 > **getCurrentToolExecutions**(): [`ToolExecutionContext`](../type-aliases/ToolExecutionContext.md)[]
 
-Defined in: [neurolink.ts:12765](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12765)
+Defined in: [neurolink.ts:12781](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12781)
 
 Get current tool execution contexts for stream metadata
 
@@ -1133,7 +1133,7 @@ Get current tool execution contexts for stream metadata
 
 > **getToolExecutionHistory**(): [`ToolExecutionSummary`](../type-aliases/ToolExecutionSummary.md)[]
 
-Defined in: [neurolink.ts:12772](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12772)
+Defined in: [neurolink.ts:12788](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12788)
 
 Get tool execution history
 
@@ -1147,7 +1147,7 @@ Get tool execution history
 
 > **clearCurrentStreamExecutions**(): `void`
 
-Defined in: [neurolink.ts:12779](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12779)
+Defined in: [neurolink.ts:12795](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12795)
 
 Clear current stream tool executions (called at stream start)
 
@@ -1161,7 +1161,7 @@ Clear current stream tool executions (called at stream start)
 
 > **registerTool**(`name`, `tool`, `options?`): `void`
 
-Defined in: [neurolink.ts:12795](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12795)
+Defined in: [neurolink.ts:12811](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12811)
 
 Register a custom tool that will be available to all AI providers
 
@@ -1207,7 +1207,7 @@ Tool in MCPExecutableTool format (unified MCP protocol type)
 
 > **setToolContext**(`context`): `void`
 
-Defined in: [neurolink.ts:12946](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12946)
+Defined in: [neurolink.ts:12962](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12962)
 
 Set the context that will be passed to tools during execution
 This context will be merged with any runtime context passed by the AI model
@@ -1230,7 +1230,7 @@ Context object containing session info, tokens, shop data, etc.
 
 > **getToolContext**(): `Record`\<`string`, `unknown`\> \| `undefined`
 
-Defined in: [neurolink.ts:12961](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12961)
+Defined in: [neurolink.ts:12977](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12977)
 
 Get the current tool execution context
 
@@ -1246,7 +1246,7 @@ Current context or undefined if not set
 
 > **clearToolContext**(): `void`
 
-Defined in: [neurolink.ts:12970](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12970)
+Defined in: [neurolink.ts:12986](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12986)
 
 Clear the tool execution context
 
@@ -1260,7 +1260,7 @@ Clear the tool execution context
 
 > **registerTools**(`tools`): `void`
 
-Defined in: [neurolink.ts:12982](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12982)
+Defined in: [neurolink.ts:12998](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L12998)
 
 Register multiple tools at once - Supports both object and array formats
 
@@ -1285,7 +1285,7 @@ Array format (Lighthouse compatible): [{ name: string, tool: MCPExecutableTool }
 
 > **unregisterTool**(`name`): `boolean`
 
-Defined in: [neurolink.ts:13005](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13005)
+Defined in: [neurolink.ts:13021](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13021)
 
 Unregister a custom tool
 
@@ -1309,7 +1309,7 @@ true if the tool was removed, false if it didn't exist
 
 > **useToolMiddleware**(`middleware`): `this`
 
-Defined in: [neurolink.ts:13024](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13024)
+Defined in: [neurolink.ts:13040](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13040)
 
 Register a global tool middleware that runs on every tool execution.
 Middleware receives the tool, params, context, and a next() function.
@@ -1334,7 +1334,7 @@ this (for chaining)
 
 > **getToolMiddlewares**(): [`ToolMiddleware`](../type-aliases/ToolMiddleware.md)[]
 
-Defined in: [neurolink.ts:13037](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13037)
+Defined in: [neurolink.ts:13053](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13053)
 
 Get all registered tool middlewares
 
@@ -1348,7 +1348,7 @@ Get all registered tool middlewares
 
 > **flushToolBatch**(): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:13044](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13044)
+Defined in: [neurolink.ts:13060](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13060)
 
 Flush any pending batched tool calls immediately
 
@@ -1362,7 +1362,7 @@ Flush any pending batched tool calls immediately
 
 > **getMCPEnhancementsConfig**(): [`MCPEnhancementsConfig`](../type-aliases/MCPEnhancementsConfig.md) \| `undefined`
 
-Defined in: [neurolink.ts:13053](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13053)
+Defined in: [neurolink.ts:13069](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13069)
 
 Get the current MCP enhancements configuration
 
@@ -1376,7 +1376,7 @@ Get the current MCP enhancements configuration
 
 > **updateAgenticLoopReport**(`sessionId`, `report`, `userId?`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:13076](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13076)
+Defined in: [neurolink.ts:13092](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13092)
 
 Update agentic loop report metadata for a conversation session.
 Upserts a report entry by reportId — updates existing or adds new.
@@ -1426,7 +1426,7 @@ await neurolink.updateAgenticLoopReport("session-123", {
 
 > **getCustomTools**(): `Map`\<`string`, \{ `name`: `string`; `description`: `string`; `inputSchema?`: `object`; `execute?`: (`params`, `context?`) => `unknown`; \}\>
 
-Defined in: [neurolink.ts:13112](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13112)
+Defined in: [neurolink.ts:13128](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13128)
 
 Get all registered custom tools
 
@@ -1442,7 +1442,7 @@ Map of tool names to MCPExecutableTool format
 
 > **addInMemoryMCPServer**(`serverId`, `serverInfo`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:13250](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13250)
+Defined in: [neurolink.ts:13266](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13266)
 
 Add an in-memory MCP server (from git diff)
 Allows registration of pre-instantiated server objects
@@ -1471,7 +1471,7 @@ Server configuration
 
 > **getInMemoryServers**(): `Map`\<`string`, [`MCPServerInfo`](../type-aliases/MCPServerInfo.md)\>
 
-Defined in: [neurolink.ts:13294](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13294)
+Defined in: [neurolink.ts:13310](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13310)
 
 Get all registered in-memory servers as a Map for ID-based lookup.
 
@@ -1494,7 +1494,7 @@ Map of server IDs to MCPServerInfo
 
 > **getInMemoryServerInfos**(): [`MCPServerInfo`](../type-aliases/MCPServerInfo.md)[]
 
-Defined in: [neurolink.ts:13321](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13321)
+Defined in: [neurolink.ts:13337](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13337)
 
 Get in-memory servers as an array of MCPServerInfo.
 
@@ -1524,7 +1524,7 @@ Array of MCPServerInfo for in-memory servers
 
 > **getAutoDiscoveredServerInfos**(): [`MCPServerInfo`](../type-aliases/MCPServerInfo.md)[]
 
-Defined in: [neurolink.ts:13337](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13337)
+Defined in: [neurolink.ts:13353](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13353)
 
 Get auto-discovered servers as MCPServerInfo - ZERO conversion needed
 
@@ -1540,7 +1540,7 @@ Array of MCPServerInfo
 
 > **executeTool**\<`T`\>(`toolName`, `params?`, `options?`): `Promise`\<`T`\>
 
-Defined in: [neurolink.ts:13349](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13349)
+Defined in: [neurolink.ts:13365](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L13365)
 
 Execute a specific tool by name with robust error handling
 Supports both custom tools and MCP server tools with timeout, retry, and circuit breaker patterns
@@ -1631,7 +1631,7 @@ Tool execution result
 
 > **getAllAvailableTools**(): `Promise`\<[`ToolInfo`](../type-aliases/ToolInfo.md)[]\>
 
-Defined in: [neurolink.ts:14449](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14449)
+Defined in: [neurolink.ts:14465](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14465)
 
 ##### Returns
 
@@ -1643,7 +1643,7 @@ Defined in: [neurolink.ts:14449](https://github.com/juspay/neurolink/blob/releas
 
 > **getProviderStatus**(`options?`): `Promise`\<[`ProviderStatus`](../type-aliases/ProviderStatus.md)[]\>
 
-Defined in: [neurolink.ts:14631](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14631)
+Defined in: [neurolink.ts:14647](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14647)
 
 Get comprehensive status of all AI providers
 Primary method for provider health checking and diagnostics
@@ -1666,7 +1666,7 @@ Primary method for provider health checking and diagnostics
 
 > **testProvider**(`providerName`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:14812](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14812)
+Defined in: [neurolink.ts:14828](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14828)
 
 Test a specific AI provider's connectivity and authentication
 
@@ -1690,7 +1690,7 @@ Promise resolving to true if provider is working
 
 > **getBestProvider**(`requestedProvider?`): `Promise`\<`string`\>
 
-Defined in: [neurolink.ts:14844](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14844)
+Defined in: [neurolink.ts:14860](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14860)
 
 Get the best available AI provider based on configuration and availability
 
@@ -1714,7 +1714,7 @@ Promise resolving to the best provider name
 
 > **getAvailableProviders**(): `Promise`\<`string`[]\>
 
-Defined in: [neurolink.ts:14853](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14853)
+Defined in: [neurolink.ts:14869](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14869)
 
 Get list of all available AI provider names
 
@@ -1730,7 +1730,7 @@ Array of supported provider names
 
 > **isValidProvider**(`providerName`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:14863](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14863)
+Defined in: [neurolink.ts:14879](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14879)
 
 Validate if a provider name is supported
 
@@ -1754,7 +1754,7 @@ True if provider name is valid
 
 > **getMCPStatus**(): `Promise`\<[`MCPStatus`](../type-aliases/MCPStatus.md)\>
 
-Defined in: [neurolink.ts:14876](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14876)
+Defined in: [neurolink.ts:14892](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14892)
 
 Get comprehensive MCP (Model Context Protocol) status information
 
@@ -1770,7 +1770,7 @@ Promise resolving to MCP status details
 
 > **listMCPServers**(): `Promise`\<[`MCPServerInfo`](../type-aliases/MCPServerInfo.md)[]\>
 
-Defined in: [neurolink.ts:14946](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14946)
+Defined in: [neurolink.ts:14962](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14962)
 
 List all configured MCP servers with their status
 
@@ -1786,7 +1786,7 @@ Promise resolving to array of MCP server information
 
 > **testMCPServer**(`serverId`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:14961](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14961)
+Defined in: [neurolink.ts:14977](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L14977)
 
 Test connectivity to a specific MCP server
 
@@ -1810,7 +1810,7 @@ Promise resolving to true if server is reachable
 
 > **hasProviderEnvVars**(`providerName`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:15002](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15002)
+Defined in: [neurolink.ts:15018](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15018)
 
 Check if a provider has the required environment variables configured
 
@@ -1834,7 +1834,7 @@ Promise resolving to true if provider has required env vars
 
 > **checkProviderHealth**(`providerName`, `options?`): `Promise`\<\{ `provider`: `string`; `isHealthy`: `boolean`; `isConfigured`: `boolean`; `hasApiKey`: `boolean`; `lastChecked`: `Date`; `error?`: `string`; `warning?`: `string`; `responseTime?`: `number`; `configurationIssues`: `string`[]; `recommendations`: `string`[]; \}\>
 
-Defined in: [neurolink.ts:15028](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15028)
+Defined in: [neurolink.ts:15044](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15044)
 
 Perform comprehensive health check on a specific provider
 
@@ -1878,7 +1878,7 @@ Promise resolving to detailed health status
 
 > **checkAllProvidersHealth**(`options?`): `Promise`\<`object`[]\>
 
-Defined in: [neurolink.ts:15074](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15074)
+Defined in: [neurolink.ts:15090](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15090)
 
 Check health of all supported providers
 
@@ -1916,7 +1916,7 @@ Promise resolving to array of health statuses for all providers
 
 > **getProviderHealthSummary**(): `Promise`\<\{ `total`: `number`; `healthy`: `number`; `configured`: `number`; `hasIssues`: `number`; `healthyProviders`: `string`[]; `unhealthyProviders`: `string`[]; `recommendations`: `string`[]; \}\>
 
-Defined in: [neurolink.ts:15118](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15118)
+Defined in: [neurolink.ts:15134](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15134)
 
 Get a summary of provider health across all supported providers
 
@@ -1932,7 +1932,7 @@ Promise resolving to health summary statistics
 
 > **clearProviderHealthCache**(`providerName?`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:15165](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15165)
+Defined in: [neurolink.ts:15181](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15181)
 
 Clear provider health cache (useful for re-testing after configuration changes)
 
@@ -1954,7 +1954,7 @@ Optional specific provider to clear cache for
 
 > **getToolExecutionMetrics**(): `Record`\<`string`, \{ `totalExecutions`: `number`; `successfulExecutions`: `number`; `failedExecutions`: `number`; `successRate`: `number`; `averageExecutionTime`: `number`; `lastExecutionTime`: `number`; `errorCategories`: `Record`\<`string`, `number`\>; \}\>
 
-Defined in: [neurolink.ts:15176](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15176)
+Defined in: [neurolink.ts:15192](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15192)
 
 Get execution metrics for all tools
 
@@ -1970,7 +1970,7 @@ Object with execution metrics for each tool
 
 > **setModelAliasConfig**(`config`): `void`
 
-Defined in: [neurolink.ts:15220](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15220)
+Defined in: [neurolink.ts:15236](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15236)
 
 NL-004: Set model alias/deprecation configuration.
 Models in the alias map will be warned, redirected, or blocked based on their action.
@@ -1993,7 +1993,7 @@ Model alias configuration with aliases map
 
 > **getToolCircuitBreakerStatus**(): `Record`\<`string`, \{ `state`: `"closed"` \| `"open"` \| `"half-open"`; `failureCount`: `number`; `isHealthy`: `boolean`; \}\>
 
-Defined in: [neurolink.ts:15233](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15233)
+Defined in: [neurolink.ts:15249](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15249)
 
 Get circuit breaker status for all tools
 
@@ -2009,7 +2009,7 @@ Object with circuit breaker status for each tool
 
 > **resetToolCircuitBreaker**(`toolName`): `void`
 
-Defined in: [neurolink.ts:15268](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15268)
+Defined in: [neurolink.ts:15284](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15284)
 
 Reset circuit breaker for a specific tool
 
@@ -2031,7 +2031,7 @@ Name of the tool to reset circuit breaker for
 
 > **clearToolExecutionMetrics**(): `void`
 
-Defined in: [neurolink.ts:15285](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15285)
+Defined in: [neurolink.ts:15301](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15301)
 
 Clear all tool execution metrics
 
@@ -2045,7 +2045,7 @@ Clear all tool execution metrics
 
 > **getToolHealthReport**(): `Promise`\<\{ `totalTools`: `number`; `healthyTools`: `number`; `unhealthyTools`: `number`; `tools`: `Record`\<`string`, \{ `name`: `string`; `isHealthy`: `boolean`; `metrics`: \{ `totalExecutions`: `number`; `successRate`: `number`; `averageExecutionTime`: `number`; `lastExecutionTime`: `number`; `errorCategories`: `Record`\<`string`, `number`\>; \}; `circuitBreaker`: \{ `state`: `"closed"` \| `"open"` \| `"half-open"`; `failureCount`: `number`; \}; `issues`: `string`[]; `recommendations`: `string`[]; \}\>; \}\>
 
-Defined in: [neurolink.ts:15294](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15294)
+Defined in: [neurolink.ts:15310](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15310)
 
 Get comprehensive tool health report
 
@@ -2061,7 +2061,7 @@ Detailed health report for all tools
 
 > **ensureConversationMemoryInitialized**(): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:15449](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15449)
+Defined in: [neurolink.ts:15465](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15465)
 
 Initialize conversation memory if enabled (public method for explicit initialization)
 This is useful for testing or when you want to ensure conversation memory is ready
@@ -2078,7 +2078,7 @@ Promise resolving to true if initialization was successful, false otherwise
 
 > **getConversationStats**(): `Promise`\<[`ConversationMemoryStats`](../type-aliases/ConversationMemoryStats.md)\>
 
-Defined in: [neurolink.ts:15469](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15469)
+Defined in: [neurolink.ts:15485](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15485)
 
 Get conversation memory statistics (public API)
 
@@ -2092,7 +2092,7 @@ Get conversation memory statistics (public API)
 
 > **getConversationHistory**(`sessionId`): `Promise`\<[`ChatMessage`](../type-aliases/ChatMessage.md)[]\>
 
-Defined in: [neurolink.ts:15496](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15496)
+Defined in: [neurolink.ts:15512](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15512)
 
 Get complete conversation history for a specific session (public API)
 
@@ -2116,7 +2116,7 @@ Array of ChatMessage objects in chronological order, or empty array if session d
 
 > **clearConversationSession**(`sessionId`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:15552](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15552)
+Defined in: [neurolink.ts:15568](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15568)
 
 Clear conversation history for a specific session (public API)
 
@@ -2136,7 +2136,7 @@ Clear conversation history for a specific session (public API)
 
 > **clearAllConversations**(): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:15578](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15578)
+Defined in: [neurolink.ts:15594](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15594)
 
 Clear all conversation history (public API)
 
@@ -2150,7 +2150,7 @@ Clear all conversation history (public API)
 
 > **listSessions**(`userId?`): `Promise`\<[`SessionListItem`](../type-aliases/SessionListItem.md)[]\>
 
-Defined in: [neurolink.ts:15606](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15606)
+Defined in: [neurolink.ts:15622](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15622)
 
 List all conversation sessions with metadata (public API)
 
@@ -2174,7 +2174,7 @@ Array of session list items with metadata
 
 > **exportSession**(`sessionId`, `options?`): `Promise`\<[`SessionExport`](../type-aliases/SessionExport.md) \| `null`\>
 
-Defined in: [neurolink.ts:15655](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15655)
+Defined in: [neurolink.ts:15671](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15671)
 
 Export a single session with full history and metadata (public API)
 
@@ -2210,7 +2210,7 @@ Session export object with full history
 
 > **exportAllSessions**(`userId?`, `options?`): `Promise`\<[`SessionExport`](../type-aliases/SessionExport.md)[]\>
 
-Defined in: [neurolink.ts:15740](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15740)
+Defined in: [neurolink.ts:15756](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15756)
 
 Export all sessions for a user (public API)
 
@@ -2246,7 +2246,7 @@ Array of session exports
 
 > **storeToolExecutions**(`sessionId`, `userId`, `toolCalls`, `toolResults`, `currentTime?`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:15804](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15804)
+Defined in: [neurolink.ts:15820](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15820)
 
 Store tool executions in conversation memory if enabled and Redis is configured
 
@@ -2294,7 +2294,7 @@ Promise resolving when storage is complete
 
 > **isToolExecutionStorageAvailable**(): `boolean`
 
-Defined in: [neurolink.ts:15874](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15874)
+Defined in: [neurolink.ts:15890](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15890)
 
 Check if tool execution storage is available.
 
@@ -2315,7 +2315,7 @@ whether the active memory backend can persist tool executions
 
 > **getSessionMessages**(`sessionId`, `userId?`): `Promise`\<[`ChatMessage`](../type-aliases/ChatMessage.md)[]\>
 
-Defined in: [neurolink.ts:15884](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15884)
+Defined in: [neurolink.ts:15900](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15900)
 
 Get the raw messages array for a session.
 Returns the full messages list without context filtering or summarization.
@@ -2344,7 +2344,7 @@ Array of ChatMessage objects, or empty array if session doesn't exist
 
 > **setSessionMessages**(`sessionId`, `messages`, `userId?`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:15925](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15925)
+Defined in: [neurolink.ts:15941](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15941)
 
 Replace the entire messages array for a session.
 
@@ -2378,7 +2378,7 @@ Optional user ID for scoped Redis key lookup
 
 > **modifyLastAssistantMessage**(`sessionId`, `transformer`, `userId?`): `Promise`\<`boolean`\>
 
-Defined in: [neurolink.ts:15973](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15973)
+Defined in: [neurolink.ts:15989](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L15989)
 
 Modify the last assistant message in a session using a transformer function.
 Convenience wrapper around getSessionMessages/setSessionMessages.
@@ -2415,7 +2415,7 @@ true if a message was modified, false if no assistant message was found
 
 > **addExternalMCPServer**(`serverId`, `config`): `Promise`\<[`ExternalMCPOperationResult`](../type-aliases/ExternalMCPOperationResult.md)\<[`ExternalMCPServerInstance`](../type-aliases/ExternalMCPServerInstance.md)\>\>
 
-Defined in: [neurolink.ts:16004](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16004)
+Defined in: [neurolink.ts:16020](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16020)
 
 Add an external MCP server
 Automatically discovers and registers tools from the server
@@ -2446,7 +2446,7 @@ Operation result with server instance
 
 > **removeExternalMCPServer**(`serverId`): `Promise`\<[`ExternalMCPOperationResult`](../type-aliases/ExternalMCPOperationResult.md)\<`void`\>\>
 
-Defined in: [neurolink.ts:16091](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16091)
+Defined in: [neurolink.ts:16107](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16107)
 
 Remove an external MCP server
 Stops the server and removes all its tools
@@ -2471,7 +2471,7 @@ Operation result
 
 > **listExternalMCPServers**(): `object`[]
 
-Defined in: [neurolink.ts:16143](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16143)
+Defined in: [neurolink.ts:16159](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16159)
 
 List all external MCP servers
 
@@ -2487,7 +2487,7 @@ Array of server health information
 
 > **getExternalMCPServer**(`serverId`): [`ExternalMCPServerInstance`](../type-aliases/ExternalMCPServerInstance.md) \| `undefined`
 
-Defined in: [neurolink.ts:16172](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16172)
+Defined in: [neurolink.ts:16188](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16188)
 
 Get external MCP server status
 
@@ -2511,7 +2511,7 @@ Server instance or undefined if not found
 
 > **executeExternalMCPTool**(`serverId`, `requestedToolName`, `parameters`, `options?`): `Promise`\<`unknown`\>
 
-Defined in: [neurolink.ts:16186](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16186)
+Defined in: [neurolink.ts:16202](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16202)
 
 Execute a tool from an external MCP server
 
@@ -2553,7 +2553,7 @@ Tool execution result
 
 > **getExternalMCPTools**(): [`ExternalMCPToolInfo`](../type-aliases/ExternalMCPToolInfo.md)[]
 
-Defined in: [neurolink.ts:16385](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16385)
+Defined in: [neurolink.ts:16401](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16401)
 
 Get all tools from external MCP servers
 
@@ -2569,7 +2569,7 @@ Array of external tool information
 
 > **getExternalMCPServerTools**(`serverId`): [`ExternalMCPToolInfo`](../type-aliases/ExternalMCPToolInfo.md)[]
 
-Defined in: [neurolink.ts:16394](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16394)
+Defined in: [neurolink.ts:16410](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16410)
 
 Get tools from a specific external MCP server
 
@@ -2593,7 +2593,7 @@ Array of tool information for the server
 
 > **testExternalMCPConnection**(`config`): `Promise`\<[`BatchOperationResult`](../type-aliases/BatchOperationResult.md)\>
 
-Defined in: [neurolink.ts:16403](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16403)
+Defined in: [neurolink.ts:16419](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16419)
 
 Test connection to an external MCP server
 
@@ -2617,7 +2617,7 @@ Test result with connection status
 
 > **getExternalMCPStatistics**(): `object`
 
-Defined in: [neurolink.ts:16431](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16431)
+Defined in: [neurolink.ts:16447](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16447)
 
 Get external MCP server manager statistics
 
@@ -2657,7 +2657,7 @@ Statistics about external servers and tools
 
 > **shutdownExternalMCPServers**(): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:16446](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16446)
+Defined in: [neurolink.ts:16462](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16462)
 
 Shutdown all external MCP servers
 Called automatically on process exit
@@ -2672,7 +2672,7 @@ Called automatically on process exit
 
 > **getElicitationManager**(): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16484](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16484)
+Defined in: [neurolink.ts:16500](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16500)
 
 Get the global elicitation manager for interactive tool input
 Elicitation allows tools to request additional information from users during execution
@@ -2703,7 +2703,7 @@ elicitationManager.registerHandler(async (request) => {
 
 > **registerElicitationHandler**(`handler`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:16512](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16512)
+Defined in: [neurolink.ts:16528](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16528)
 
 Register an elicitation handler for interactive tool input
 Handlers are called when tools need user input during execution
@@ -2741,7 +2741,7 @@ neurolink.registerElicitationHandler(async (request) => {
 
 > **getMultiServerManager**(): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16535](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16535)
+Defined in: [neurolink.ts:16551](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16551)
 
 Get the multi-server manager for load balancing and coordination
 Allows managing multiple MCP servers with failover and load balancing
@@ -2770,7 +2770,7 @@ await multiServer.createServerGroup("ai-tools", {
 
 > **getEnhancedToolDiscovery**(): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16560](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16560)
+Defined in: [neurolink.ts:16576](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16576)
 
 Get the enhanced tool discovery service
 Provides advanced search, filtering, and compatibility checking for tools
@@ -2800,7 +2800,7 @@ const results = await discovery.searchTools({
 
 > **getMCPRegistryClient**(): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16587](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16587)
+Defined in: [neurolink.ts:16603](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16603)
 
 Get the MCP registry client for discovering servers from registries
 Supports multiple registry sources (official, community, custom)
@@ -2832,7 +2832,7 @@ const githubServer = registryClient.getWellKnownServer("github");
 
 > **exposeAgentAsTool**(`agent`, `options?`): `Promise`\<[`ExposureResult`](../type-aliases/ExposureResult.md)\>
 
-Defined in: [neurolink.ts:16615](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16615)
+Defined in: [neurolink.ts:16631](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16631)
 
 Expose a NeuroLink agent as an MCP tool
 This allows agents to be called by other systems via MCP
@@ -2909,7 +2909,7 @@ const tool = await neurolink.exposeAgentAsTool(agent, {
 
 > **exposeWorkflowAsTool**(`workflow`, `options?`): `Promise`\<[`ExposureResult`](../type-aliases/ExposureResult.md)\>
 
-Defined in: [neurolink.ts:16656](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16656)
+Defined in: [neurolink.ts:16672](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16672)
 
 Expose a workflow as an MCP tool
 This allows workflows to be called by other systems via MCP
@@ -2990,7 +2990,7 @@ const tool = await neurolink.exposeWorkflowAsTool(workflow, {
 
 > **getToolIntegrationManager**(): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16695](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16695)
+Defined in: [neurolink.ts:16711](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16711)
 
 Get the tool integration manager for middleware and elicitation
 Provides advanced tool wrapping with confirmation, timeout, retry, etc.
@@ -3020,7 +3020,7 @@ integration.registerTool(myTool, {
 
 > **convertToolsToMCPFormat**(`tools`, `options?`): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16717](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16717)
+Defined in: [neurolink.ts:16733](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16733)
 
 Convert NeuroLink tools to MCP format
 Useful for exposing local tools to external MCP clients
@@ -3061,7 +3061,7 @@ const mcpTools = neurolink.convertToolsToMCPFormat([
 
 > **convertToolsFromMCPFormat**(`tools`, `options?`): `Promise`\<`any`\>
 
-Defined in: [neurolink.ts:16756](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16756)
+Defined in: [neurolink.ts:16772](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16772)
 
 Convert MCP tools to NeuroLink format
 Useful for importing tools from external MCP servers
@@ -3102,7 +3102,7 @@ const neurolinkTools = neurolink.convertToolsFromMCPFormat(externalTools, {
 
 > **getToolAnnotations**(`toolName`): `Promise`\<\{ `annotations`: [`MCPToolAnnotations`](../type-aliases/MCPToolAnnotations.md); `summary`: `string`; \} \| `null`\>
 
-Defined in: [neurolink.ts:16779](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16779)
+Defined in: [neurolink.ts:16795](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L16795)
 
 Get tool annotations and safety information
 Provides insights about tool behavior, safety levels, and retry-ability
@@ -3134,7 +3134,7 @@ const annotations = await neurolink.getToolAnnotations("deleteFile");
 
 > **createEvaluationPipeline**(`configOrPreset`): `Promise`\<[`EvaluationPipeline`](EvaluationPipeline.md)\>
 
-Defined in: [neurolink.ts:17018](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17018)
+Defined in: [neurolink.ts:17034](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17034)
 
 Create an evaluation pipeline with the specified configuration or preset.
 Pipelines orchestrate multiple scorers to evaluate AI responses comprehensively.
@@ -3185,7 +3185,7 @@ const pipeline = await neurolink.createEvaluationPipeline({
 
 > **evaluate**(`input`, `options?`): `Promise`\<[`PipelineResult`](../type-aliases/PipelineResult.md)\>
 
-Defined in: [neurolink.ts:17110](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17110)
+Defined in: [neurolink.ts:17126](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17126)
 
 Evaluate an AI response using the specified pipeline or scorers.
 This is a convenience method that creates a pipeline and executes it in one call.
@@ -3287,7 +3287,7 @@ const result = await neurolink.evaluate(
 
 > **score**(`scorerId`, `input`, `config?`): `Promise`\<[`ScoreResult`](../type-aliases/ScoreResult.md)\>
 
-Defined in: [neurolink.ts:17248](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17248)
+Defined in: [neurolink.ts:17264](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17264)
 
 Score a response using a single scorer.
 Useful for quick, targeted evaluations without the overhead of a full pipeline.
@@ -3356,7 +3356,7 @@ const result = await neurolink.score(
 
 > **getAvailableScorers**(`options?`): `Promise`\<[`ScorerMetadata`](../type-aliases/ScorerMetadata.md)[]\>
 
-Defined in: [neurolink.ts:17334](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17334)
+Defined in: [neurolink.ts:17350](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17350)
 
 Get a list of all available scorers and their metadata.
 Useful for discovering what evaluation capabilities are available.
@@ -3417,7 +3417,7 @@ const ruleBasedScorers = await neurolink.getAvailableScorers({
 
 > **getEvaluationPresets**(): `Promise`\<`string`[]\>
 
-Defined in: [neurolink.ts:17380](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17380)
+Defined in: [neurolink.ts:17396](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17396)
 
 Get a list of available evaluation pipeline presets.
 Presets are pre-configured pipelines for common evaluation scenarios.
@@ -3443,7 +3443,7 @@ console.log("Available presets:", presets);
 
 > **getEvaluationPreset**(`presetName`): `Promise`\<[`PipelineConfig`](../type-aliases/PipelineConfig.md)\>
 
-Defined in: [neurolink.ts:17403](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17403)
+Defined in: [neurolink.ts:17419](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17419)
 
 Get details of a specific evaluation preset.
 
@@ -3479,7 +3479,7 @@ console.log("Pass threshold:", ragPreset.passThreshold);
 
 > **createAgent**(`definition`): `Promise`\<[`Agent`](Agent.md)\>
 
-Defined in: [neurolink.ts:17453](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17453)
+Defined in: [neurolink.ts:17469](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17469)
 
 Create an Agent instance for multi-agent orchestration.
 
@@ -3531,7 +3531,7 @@ const result = await researcher.execute("Find recent AI breakthroughs");
 
 > **createNetwork**(`config`): `Promise`\<[`AgentNetwork`](AgentNetwork.md)\>
 
-Defined in: [neurolink.ts:17515](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17515)
+Defined in: [neurolink.ts:17531](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17531)
 
 Create an AgentNetwork for multi-agent orchestration.
 
@@ -3605,7 +3605,7 @@ const result = await network.execute({
 
 > **createWorkerInstance**(`options?`): `NeuroLink`
 
-Defined in: [neurolink.ts:17547](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17547)
+Defined in: [neurolink.ts:17563](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17563)
 
 Create a worker-mode NeuroLink instance for sub-agent execution.
 
@@ -3645,7 +3645,7 @@ A new worker-mode NeuroLink instance
 
 > **runIsolatedAgent**(`definition`, `input`, `options?`): `Promise`\<[`AgentRunOutcome`](../type-aliases/AgentRunOutcome.md)\>
 
-Defined in: [neurolink.ts:17646](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17646)
+Defined in: [neurolink.ts:17662](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17662)
 
 Run an isolated sub-agent: a worker instance (see
 [createWorkerInstance](#createworkerinstance)) executes a tool-using research pass under
@@ -3695,7 +3695,7 @@ The run outcome
 
 > **continueAgent**(`handle`, `guidance?`): `Promise`\<[`AgentRunOutcome`](../type-aliases/AgentRunOutcome.md)\>
 
-Defined in: [neurolink.ts:17665](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17665)
+Defined in: [neurolink.ts:17681](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17681)
 
 Resume a leashed isolated-agent run by handle. `guidance`, when given,
 is appended as a user turn before the next leg — the supervisor's
@@ -3728,7 +3728,7 @@ The next leg's outcome (or the final outcome)
 
 > **stopAgent**(`handle`): `Promise`\<[`AgentRunOutcome`](../type-aliases/AgentRunOutcome.md)\>
 
-Defined in: [neurolink.ts:17681](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17681)
+Defined in: [neurolink.ts:17697](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17697)
 
 Stop a leashed isolated-agent run: dispose its worker and return the
 final outcome (mechanical digest over everything gathered so far).
@@ -3753,7 +3753,7 @@ The final outcome
 
 > **registerAgentTool**(`definition`, `options?`): `Promise`\<\{ `name`: `string`; \}\>
 
-Defined in: [neurolink.ts:17699](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17699)
+Defined in: [neurolink.ts:17715](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17715)
 
 Register an isolated agent as a delegation tool on THIS instance, so
 its existing generate() loop can delegate — no second router generate.
@@ -3791,7 +3791,7 @@ The registered tool name
 
 > **registerTaskTools**(): `void`
 
-Defined in: [neurolink.ts:17732](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17732)
+Defined in: [neurolink.ts:17748](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17748)
 
 Register the task CHECKLIST toolset — `tasks_create`, `tasks_update`,
 `tasks_list` — on this instance (TodoWrite-style planning for a
@@ -3827,7 +3827,7 @@ id for that one call.
 
 > **getTaskState**(`sessionId?`): [`ChecklistState`](../type-aliases/ChecklistState.md)
 
-Defined in: [neurolink.ts:17758](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17758)
+Defined in: [neurolink.ts:17774](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17774)
 
 Read a session's task checklist — synchronous, so a completeness gate is
 one line of host code:
@@ -3853,7 +3853,7 @@ instance's tool-context session, or its default checklist).
 
 > **clearTaskState**(`sessionId?`): `boolean`
 
-Defined in: [neurolink.ts:17766](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17766)
+Defined in: [neurolink.ts:17782](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17782)
 
 Drop a session's checklist. Returns whether there was one to drop.
 Omit `sessionId` to clear the session the tools currently write to.
@@ -3874,7 +3874,7 @@ Omit `sessionId` to clear the session the tools currently write to.
 
 > **registerDelegationTools**(`options?`): `void`
 
-Defined in: [neurolink.ts:17793](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17793)
+Defined in: [neurolink.ts:17809](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17809)
 
 Register the background-delegation toolset — `delegate_task` and
 `collect_results` — on this instance. Opt-in and idempotent: existing
@@ -3913,7 +3913,7 @@ Depth ceiling, pool raise, and queue wait
 
 > **spawnDelegate**(`options`): `Promise`\<[`DelegateHandle`](../type-aliases/DelegateHandle.md)\>
 
-Defined in: [neurolink.ts:17833](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17833)
+Defined in: [neurolink.ts:17849](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17849)
 
 Start a background worker and get its handle immediately — before it has
 run anything, and long before it finishes.
@@ -3957,7 +3957,7 @@ when the task is empty or the caller is at the depth ceiling
 
 > **collectDelegates**(`request`): `Promise`\<[`DelegateCollectResult`](../type-aliases/DelegateCollectResult.md)\>
 
-Defined in: [neurolink.ts:17844](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17844)
+Defined in: [neurolink.ts:17860](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17860)
 
 Claim finished background workers — in COMPLETION order, which has nothing
 to do with spawn order. Each outcome is handed out exactly once.
@@ -3982,7 +3982,7 @@ Claimed outcomes plus what is still pending/ready
 
 > **cancelDelegates**(`workerId?`): `Promise`\<`number`\>
 
-Defined in: [neurolink.ts:17858](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17858)
+Defined in: [neurolink.ts:17874](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17874)
 
 Cancel background workers: one by id, or every outstanding worker this
 instance spawned. Cancelled workers still settle into a claimable outcome
@@ -4008,7 +4008,7 @@ How many workers were cancelled
 
 > **getArtifactStore**(): [`ArtifactStore`](../type-aliases/ArtifactStore.md)
 
-Defined in: [neurolink.ts:17881](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17881)
+Defined in: [neurolink.ts:17897](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17897)
 
 This instance's artifact store, created on first use.
 
@@ -4034,7 +4034,7 @@ The artifact store backing [bankArtifact](#bankartifact) / [readArtifact](#reada
 
 > **setArtifactStore**(`store`): `void`
 
-Defined in: [neurolink.ts:17911](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17911)
+Defined in: [neurolink.ts:17927](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17927)
 
 Replace this instance's artifact store.
 
@@ -4072,7 +4072,7 @@ Any [ArtifactStore](../type-aliases/ArtifactStore.md)
 
 > **bankArtifact**(`payload`, `options`): `Promise`\<[`BankedArtifactRef`](../type-aliases/BankedArtifactRef.md)\>
 
-Defined in: [neurolink.ts:17999](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L17999)
+Defined in: [neurolink.ts:18015](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18015)
 
 Bank a payload to a file and get back a pointer to it.
 
@@ -4119,7 +4119,7 @@ const ref = await neurolink.bankArtifact(fullReport, {
 
 > **readArtifact**(`id`, `page?`): `Promise`\<`string` \| `null`\>
 
-Defined in: [neurolink.ts:18016](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18016)
+Defined in: [neurolink.ts:18032](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18032)
 
 Read a banked payload back from host code — the programmatic twin of the
 model's `retrieve_context({ artifactId })` call.
@@ -4151,7 +4151,7 @@ Optional character window
 
 > **registerBackgroundCommandTools**(`policy`): `void`
 
-Defined in: [neurolink.ts:18048](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18048)
+Defined in: [neurolink.ts:18064](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18064)
 
 Register the background-command toolset — `run_command_bg`,
 `command_status`, `command_output`, `command_kill` — on this instance, and
@@ -4192,7 +4192,7 @@ What may run, where, for how long, and how loudly
 
 > **setBackgroundCommandPolicy**(`policy`): `void`
 
-Defined in: [neurolink.ts:18073](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18073)
+Defined in: [neurolink.ts:18089](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18089)
 
 Declare (or replace) what this instance may execute, without registering
 the model-facing tools. Host code that only drives
@@ -4216,7 +4216,7 @@ What may run, where, for how long, and how loudly
 
 > **startBackgroundCommand**(`argv`, `options`): `Promise`\<[`BackgroundCommandHandle`](../type-aliases/BackgroundCommandHandle.md)\>
 
-Defined in: [neurolink.ts:18097](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18097)
+Defined in: [neurolink.ts:18113](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18113)
 
 Start a command in the background and get its task id immediately.
 
@@ -4263,7 +4263,7 @@ allowlisted, the policy vetoes it, or the cwd escapes the sandbox
 
 > **getBackgroundCommandStatus**(`taskId`): [`BackgroundCommandStatus`](../type-aliases/BackgroundCommandStatus.md)
 
-Defined in: [neurolink.ts:18111](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18111)
+Defined in: [neurolink.ts:18127](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18127)
 
 Everything known about one command right now — synchronous, so a
 mid-loop monitor costs nothing.
@@ -4290,7 +4290,7 @@ when the task id is unknown to this instance
 
 > **awaitBackgroundCommand**(`taskId`, `opts?`): `Promise`\<[`BackgroundCommandStatus`](../type-aliases/BackgroundCommandStatus.md)\>
 
-Defined in: [neurolink.ts:18123](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18123)
+Defined in: [neurolink.ts:18139](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18139)
 
 Wait for a command to settle. `timeoutMs` bounds the WAIT, not the
 command: when it elapses the current status is returned rather than
@@ -4322,7 +4322,7 @@ Task id from [startBackgroundCommand](#startbackgroundcommand)
 
 > **killBackgroundCommand**(`taskId`, `signal?`): `Promise`\<[`BackgroundCommandStatus`](../type-aliases/BackgroundCommandStatus.md)\>
 
-Defined in: [neurolink.ts:18138](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18138)
+Defined in: [neurolink.ts:18154](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18154)
 
 Kill a running command — SIGTERM, then SIGKILL five seconds later — and
 resolve with its settled status. Whatever it printed first is still
@@ -4352,7 +4352,7 @@ Signal to send first. Default SIGTERM
 
 > **readBackgroundCommandOutput**(`taskId`, `page`): `Promise`\<[`BackgroundCommandOutputPage`](../type-aliases/BackgroundCommandOutputPage.md)\>
 
-Defined in: [neurolink.ts:18153](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18153)
+Defined in: [neurolink.ts:18169](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18169)
 
 Read one character window of a command's output straight from its log
 file — while it is still running, or long after it finished. Offsets,
@@ -4382,7 +4382,7 @@ Which stream, and which window of it
 
 > **registerGitTools**(`options`): `void`
 
-Defined in: [neurolink.ts:18180](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18180)
+Defined in: [neurolink.ts:18196](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18196)
 
 Register the read-only git toolset — `git_log`, `git_show`, `git_diff`,
 `git_blame`, `git_merge_base`, `git_ls_files` — on this instance. Opt-in
@@ -4415,7 +4415,7 @@ Repository root, plus timeout / byte-cap / preview bounds
 
 > **runGitCommand**(`args`, `sessionId?`): `Promise`\<[`GitToolResult`](../type-aliases/GitToolResult.md)\>
 
-Defined in: [neurolink.ts:18206](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18206)
+Defined in: [neurolink.ts:18222](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18222)
 
 Run one read-only git command from host code, with the same bounding the
 tools get: the complete stdout is banked, the result carries a preview and
@@ -4450,7 +4450,7 @@ when [registerGitTools](#registergittools) has not been called
 
 > **executeNetwork**(`network`, `input`, `options?`): `Promise`\<[`NetworkExecutionResult`](../type-aliases/NetworkExecutionResult.md)\>
 
-Defined in: [neurolink.ts:18225](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18225)
+Defined in: [neurolink.ts:18241](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18241)
 
 Execute an agent network with the given input.
 
@@ -4495,7 +4495,7 @@ Network execution result with content, trace, and usage
 
 > **streamNetwork**(`network`, `input`, `options?`): `AsyncIterable`\<[`NetworkStreamChunk`](../type-aliases/NetworkStreamChunk.md)\>
 
-Defined in: [neurolink.ts:18249](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18249)
+Defined in: [neurolink.ts:18265](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18265)
 
 Stream agent network execution with real-time events.
 
@@ -4539,7 +4539,7 @@ Async iterable of network stream chunks
 
 > **createOrchestrator**(`config?`): `Promise`\<[`NetworkOrchestrator`](NetworkOrchestrator.md)\>
 
-Defined in: [neurolink.ts:18273](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18273)
+Defined in: [neurolink.ts:18289](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18289)
 
 Create a NetworkOrchestrator for managing multiple agent networks.
 
@@ -4567,7 +4567,7 @@ A new NetworkOrchestrator instance
 
 > **createCoordinator**(`config?`): `Promise`\<[`AgentCoordinator`](AgentCoordinator.md)\>
 
-Defined in: [neurolink.ts:18292](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18292)
+Defined in: [neurolink.ts:18308](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18308)
 
 Create an AgentCoordinator for managing agent coordination strategies.
 
@@ -4595,7 +4595,7 @@ A new AgentCoordinator instance
 
 > **createMessageBus**(`config?`): `Promise`\<[`MessageBus`](MessageBus.md)\>
 
-Defined in: [neurolink.ts:18310](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18310)
+Defined in: [neurolink.ts:18326](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18326)
 
 Create a MessageBus for inter-agent communication.
 
@@ -4623,7 +4623,7 @@ A new MessageBus instance
 
 > **dispose**(): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:18325](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18325)
+Defined in: [neurolink.ts:18341](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18341)
 
 Dispose of all resources and cleanup connections
 Call this method when done using the NeuroLink instance to prevent resource leaks
@@ -4639,7 +4639,7 @@ Especially important in test environments where multiple instances are created
 
 > **getToolRegistry**(): [`MCPToolRegistry`](MCPToolRegistry.md)
 
-Defined in: [neurolink.ts:18544](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18544)
+Defined in: [neurolink.ts:18560](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18560)
 
 Get the tool registry instance
 Used internally by server adapters for tool management
@@ -4656,7 +4656,7 @@ The MCPToolRegistry instance
 
 > **compactSession**(`sessionId`, `config?`): `Promise`\<[`CompactionResult`](../type-aliases/CompactionResult.md) \| `null`\>
 
-Defined in: [neurolink.ts:18552](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18552)
+Defined in: [neurolink.ts:18568](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18568)
 
 Manually trigger context compaction for a session.
 Runs the full 4-stage compaction pipeline.
@@ -4681,7 +4681,7 @@ Runs the full 4-stage compaction pipeline.
 
 > **getContextStats**(`sessionId`, `provider?`, `model?`): `Promise`\<\{ `estimatedInputTokens`: `number`; `availableInputTokens`: `number`; `usageRatio`: `number`; `shouldCompact`: `boolean`; `messageCount`: `number`; \} \| `null`\>
 
-Defined in: [neurolink.ts:18603](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18603)
+Defined in: [neurolink.ts:18619](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18619)
 
 Get context usage statistics for a session.
 Returns token counts, usage ratio, and breakdown by category.
@@ -4710,7 +4710,7 @@ Returns token counts, usage ratio, and breakdown by category.
 
 > **needsCompaction**(`sessionId`, `provider?`, `model?`): `boolean`
 
-Defined in: [neurolink.ts:18645](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18645)
+Defined in: [neurolink.ts:18661](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18661)
 
 Check if a session needs compaction.
 
@@ -4738,7 +4738,7 @@ Check if a session needs compaction.
 
 > **setAuthProvider**(`config`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:18682](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18682)
+Defined in: [neurolink.ts:18698](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18698)
 
 Set the authentication provider for the NeuroLink instance
 
@@ -4760,7 +4760,7 @@ Auth provider or configuration to create one
 
 > **getAuthProvider**(): [`AuthProvider`](../type-aliases/AuthProvider.md) \| `undefined`
 
-Defined in: [neurolink.ts:18730](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18730)
+Defined in: [neurolink.ts:18746](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18746)
 
 Get the currently configured authentication provider
 
@@ -4774,7 +4774,7 @@ Get the currently configured authentication provider
 
 > **setAuthContext**(`context`): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:18771](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18771)
+Defined in: [neurolink.ts:18787](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18787)
 
 Set the current authentication context for request handling.
 
@@ -4801,7 +4801,7 @@ The authenticated user context
 
 > **getAuthContext**(): `Promise`\<[`AuthenticatedContext`](../type-aliases/AuthenticatedContext.md) \| `undefined`\>
 
-Defined in: [neurolink.ts:18786](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18786)
+Defined in: [neurolink.ts:18802](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18802)
 
 Get the current authentication context.
 
@@ -4817,7 +4817,7 @@ Checks AsyncLocalStorage first, then falls back to the global holder.
 
 > **clearAuthContext**(): `Promise`\<`void`\>
 
-Defined in: [neurolink.ts:18794](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18794)
+Defined in: [neurolink.ts:18810](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18810)
 
 Clear the current authentication context
 
@@ -4831,7 +4831,7 @@ Clear the current authentication context
 
 > **getExternalServerManager**(): [`ExternalServerManager`](ExternalServerManager.md)
 
-Defined in: [neurolink.ts:18808](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18808)
+Defined in: [neurolink.ts:18824](https://github.com/juspay/neurolink/blob/release/src/lib/neurolink.ts#L18824)
 
 Get the external server manager instance
 Used internally by server adapters for external MCP server management

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "test:new-providers": "pnpm exec tsx test/continuous-test-suite-new-providers.ts",
     "test:matrix": "pnpm exec tsx test/continuous-test-suite-provider-matrix.ts",
     "test:matrix:cli": "pnpm exec tsx test/continuous-test-suite-provider-matrix-cli.ts",
+    "test:thinking-config": "pnpm exec tsx test/continuous-test-suite-sdk-thinking-config.ts",
     "test:mcp:spans": "pnpm exec tsx test/continuous-test-suite-mcp-spans.ts",
     "test:mcp:infra": "pnpm exec tsx test/continuous-test-suite-mcp-infra.ts",
     "test:vendor-recovery": "pnpm exec tsx test/continuous-test-suite-native-vendor-recovery.ts",

--- a/src/lib/neurolink.ts
+++ b/src/lib/neurolink.ts
@@ -5615,6 +5615,22 @@ Current user's request: ${currentInput}`;
       middleware: options.middleware,
       conversationMessages: options.conversationMessages,
       credentials: options.credentials,
+      // Extended thinking. Every provider gates it on `thinkingConfig`, so
+      // omitting the field here meant it never reached one: the request went
+      // out with no thinking block and the result carried no reasoning, with
+      // nothing raised to say the option had been discarded. This is the same
+      // failure the note above records for `disableInternalFallback` — an
+      // allowlist that silently swallows a documented option.
+      //
+      // `thinkingConfig` is the only one of the documented thinking options
+      // that `GenerateOptions` actually declares. `thinking`, `thinkingBudget`
+      // and `thinkingLevel` are folded into a `thinkingConfig` only by the CLI,
+      // in `src/lib/utils/thinkingConfig.ts`; nothing on the SDK path does that
+      // merge. They exist solely on the internal `TextGenerationOptions`, so no
+      // caller can pass them through
+      // generate() today. Declaring them is a public-type decision and is
+      // deliberately left out of this fix.
+      thinkingConfig: options.thinkingConfig,
       // Lifecycle callbacks must reach the provider so non-AI-SDK paths
       // (Vertex's native @google/genai, native Bedrock, Ollama, etc.) can
       // invoke them directly. Pipeline A also still receives them via the

--- a/src/lib/providers/anthropic/client.ts
+++ b/src/lib/providers/anthropic/client.ts
@@ -1463,15 +1463,32 @@ export class AnthropicProvider extends BaseProvider {
           },
           "anthropic.doGenerate",
         );
+        // Dropping a caller's explicit sampling parameters is exactly the
+        // kind of silent discard this change fixes elsewhere, so say so.
+        if (
+          thinking &&
+          (samplingParams.temperature !== undefined ||
+            samplingParams.topP !== undefined)
+        ) {
+          logger.debug(
+            "[anthropic] extended thinking is enabled, so temperature/top_p are omitted — Anthropic rejects any temperature but 1 while thinking is set",
+          );
+        }
         const params: Anthropic.Messages.MessageCreateParamsNonStreaming = {
           model: modelId,
           messages: cachedMessages,
           max_tokens: resolveClaudeMaxTokens(modelId, options.maxOutputTokens),
           ...(system ? { system } : {}),
-          ...(samplingParams.temperature !== undefined
+          // Extended thinking fixes sampling: Anthropic rejects any
+          // temperature but 1 while `thinking` is set, and does not honour
+          // top_p there. The CLI always sends a default temperature, so
+          // forwarding it alongside thinking turns a call that used to work
+          // into a 400. Drop the sampling knobs for exactly those turns and
+          // let Anthropic's thinking defaults stand.
+          ...(!thinking && samplingParams.temperature !== undefined
             ? { temperature: samplingParams.temperature }
             : {}),
-          ...(samplingParams.topP !== undefined
+          ...(!thinking && samplingParams.topP !== undefined
             ? { top_p: samplingParams.topP }
             : {}),
           ...(options.stopSequences && options.stopSequences.length > 0
@@ -2353,6 +2370,11 @@ export class AnthropicProvider extends BaseProvider {
             : {},
           "anthropic.executeStream",
         );
+        if (thinking && streamSamplingParams.temperature !== undefined) {
+          logger.debug(
+            "[anthropic] extended thinking is enabled, so temperature is omitted on the stream path — Anthropic rejects any temperature but 1 while thinking is set",
+          );
+        }
         return {
           model: modelId,
           messages: cachedConversation,
@@ -2362,7 +2384,9 @@ export class AnthropicProvider extends BaseProvider {
           // the adapter immediately overwrites — and forced this whole params
           // object into the streaming variant for a field it does not own.
           ...(payload.system ? { system: payload.system } : {}),
-          ...(streamSamplingParams.temperature !== undefined
+          // Same constraint on the streaming path: a temperature alongside
+          // `thinking` is rejected outright.
+          ...(!thinking && streamSamplingParams.temperature !== undefined
             ? { temperature: streamSamplingParams.temperature }
             : {}),
           ...(cachedTools && cachedTools.length > 0

--- a/test/continuous-test-suite-sdk-thinking-config.ts
+++ b/test/continuous-test-suite-sdk-thinking-config.ts
@@ -1,0 +1,297 @@
+#!/usr/bin/env tsx
+import "dotenv/config";
+
+/**
+ * Continuous Test Suite — thinkingConfig survives the SDK option allowlist, LIVE
+ *
+ * `NeuroLink.generate()` accepts a `thinkingConfig`, and the type documents it
+ * as the recommended way to switch extended thinking on. It never reached a
+ * provider.
+ *
+ * `buildGenerateTextOptions` converts the caller's public `GenerateOptions`
+ * into the internal `TextGenerationOptions` through an explicit field-by-field
+ * allowlist, and `thinkingConfig` was absent from it. Every provider gates
+ * thinking on `options.thinkingConfig`, so all of them saw `undefined`: the
+ * request went out with no thinking block and nothing was raised to say the
+ * option had been discarded. That file already carried a note recording the
+ * same failure for `disableInternalFallback`, which makes this a repeat rather
+ * than a one-off.
+ *
+ * WHY THIS ASSERTS ON THE REQUEST, NOT ON `result.reasoning`.
+ * The obvious assertion — "reasoning comes back non-empty" — is WRONG here and
+ * would fail forever. Whenever a proxy base URL is set, which is always true on
+ * the OAuth subscription path this deployment uses, the client requests the
+ * beta `redact-thinking-2026-02-12` (anthropic/client.ts:878). Anthropic honours
+ * it by returning thinking blocks whose text is redacted and whose signature is
+ * intact — captured directly: `blockTypes=[thinking,text]` with the thinking
+ * block at 0 characters and a valid signature. So an empty `result.reasoning`
+ * is CORRECT on this path and proves nothing either way.
+ *
+ * The observable fact that does distinguish the fix is whether the outbound
+ * request carries a `thinking` field. This suite therefore wraps `fetch` to
+ * record what left the process. That is observation, not substitution: the call
+ * still goes through the real public `generate()` to the real provider and the
+ * real response comes back. Nothing is stubbed.
+ *
+ * SCOPE. Only `thinkingConfig` is exercised, because it is the only thinking
+ * option the public `GenerateOptions` actually declares. `thinking`,
+ * `thinkingBudget` and `thinkingLevel` appear in the docs and in CLAUDE.md but
+ * exist solely on the internal `TextGenerationOptions`, so no caller can pass
+ * them through `generate()`. Declaring them is a public-type decision, tracked
+ * separately.
+ *
+ * THE CLI LEG IS A REGRESSION GUARD, AND IT EARNED ITS PLACE.
+ * Forwarding `thinkingConfig` is what first makes a `thinking` field reach the
+ * wire, and that immediately collided with a rule nothing had hit before:
+ * Anthropic rejects any temperature but 1 while thinking is enabled, and the
+ * CLI always sends a default temperature. So this change briefly turned a
+ * working `--thinking` invocation into a 400 — a regression introduced by the
+ * fix itself, caught only by running the release build first and finding it
+ * exited 0. The sampling knobs are now dropped whenever `thinking` is set, on
+ * both the generate and stream builders, and these cases pin that.
+ *
+ * Run: pnpm run build && npx tsx test/continuous-test-suite-sdk-thinking-config.ts
+ */
+
+import { NeuroLink } from "../dist/index.js";
+import { defineSuite, assert, runCLI } from "./helpers/harness.js";
+import { skipUnlessProviderAvailable } from "./helpers/skipIf.js";
+import { assertDistFresh } from "./helpers/distFreshness.js";
+
+assertDistFresh();
+
+const { test, runSuite } = defineSuite("SDK thinkingConfig passthrough (live)");
+
+const PROVIDER = "anthropic";
+const MODEL = "claude-sonnet-4-5-20250929";
+const PROMPT = "What is 17 * 24? Work it out step by step.";
+const BUDGET = 5000;
+
+type SeenRequest = {
+  hasThinking: boolean;
+  budgetTokens: number | undefined;
+  hasTemperature: boolean;
+};
+
+/**
+ * Record every outbound Messages request while `run` executes. Restores the
+ * original `fetch` even if the call throws, so one failing test cannot leave a
+ * wrapped `fetch` behind for the next one.
+ */
+const observeRequests = async <T>(
+  run: () => Promise<T>,
+): Promise<{ result: T; seen: SeenRequest[] }> => {
+  const seen: SeenRequest[] = [];
+  const original = globalThis.fetch;
+  globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+    if (String(input).includes("/v1/messages")) {
+      let body: Record<string, unknown>;
+      try {
+        body = JSON.parse(String(init?.body ?? "{}")) as Record<
+          string,
+          unknown
+        >;
+      } catch {
+        body = {};
+      }
+      const thinking = body.thinking as { budget_tokens?: number } | undefined;
+      seen.push({
+        hasThinking: thinking !== undefined && thinking !== null,
+        budgetTokens: thinking?.budget_tokens,
+        hasTemperature: body.temperature !== undefined,
+      });
+    }
+    return original(input, init);
+  };
+  try {
+    const result = await run();
+    return { result, seen };
+  } finally {
+    globalThis.fetch = original;
+  }
+};
+
+await test("a thinkingConfig passed to generate() reaches the request", async () => {
+  skipUnlessProviderAvailable(PROVIDER);
+
+  const { result, seen } = await observeRequests(() =>
+    new NeuroLink().generate({
+      input: { text: PROMPT },
+      provider: PROVIDER,
+      model: MODEL,
+      maxTokens: 8000,
+      disableTools: true,
+      thinkingConfig: { enabled: true, budgetTokens: BUDGET },
+    }),
+  );
+
+  // PRECONDITION 1: the turn completed. Without it an empty request list
+  // could mean the call failed early, and the assertion below would be
+  // reporting on something that never ran.
+  assert(
+    (result.content ?? "").length > 0,
+    "precondition failed: the call returned no content, so the turn never completed",
+  );
+
+  // PRECONDITION 2: a request was actually observed. An assertion about what
+  // a request contained is vacuous if no request was captured.
+  assert(
+    seen.length > 0,
+    "precondition failed: no Messages request was observed, so nothing was inspected",
+  );
+
+  // The regression. Pre-fix the allowlist discarded thinkingConfig and this
+  // field was absent from every outbound request.
+  assert(
+    seen.some((r) => r.hasThinking),
+    "no outbound request carried a thinking field, so thinkingConfig never reached the provider",
+  );
+
+  assert(
+    seen.some((r) => r.budgetTokens === BUDGET),
+    "the thinking field did not carry the budget the caller asked for",
+  );
+});
+
+await test("omitting thinkingConfig sends no thinking field", async () => {
+  skipUnlessProviderAvailable(PROVIDER);
+
+  const { result, seen } = await observeRequests(() =>
+    new NeuroLink().generate({
+      input: { text: PROMPT },
+      provider: PROVIDER,
+      model: MODEL,
+      maxTokens: 2000,
+      disableTools: true,
+    }),
+  );
+
+  assert(
+    (result.content ?? "").length > 0,
+    "precondition failed: the call returned no content, so the turn never completed",
+  );
+  assert(
+    seen.length > 0,
+    "precondition failed: no Messages request was observed, so nothing was inspected",
+  );
+
+  // The other direction: forwarding a new field through the allowlist must
+  // not switch thinking on for callers who never asked for it.
+  assert(
+    seen.every((r) => !r.hasThinking),
+    "a request carried a thinking field even though the caller set no thinkingConfig",
+  );
+});
+
+await test("the CLI still succeeds with thinking enabled", async () => {
+  skipUnlessProviderAvailable(PROVIDER);
+
+  const result = await runCLI(
+    [
+      "generate",
+      PROMPT,
+      "--provider",
+      PROVIDER,
+      "--model",
+      MODEL,
+      "--thinking",
+      "--thinkingBudget",
+      String(BUDGET),
+      "--disableTools",
+    ],
+    { timeoutMs: 180_000 },
+  );
+
+  // Exit code is the whole point: before the sampling fix this path returned a
+  // 400 because the CLI's default temperature travelled alongside `thinking`.
+  assert(
+    result.exitCode === 0,
+    "the CLI exited non-zero with thinking enabled, so a sampling parameter is still being sent alongside thinking",
+  );
+  assert(
+    result.stdout.trim().length > 0,
+    "the CLI produced no output with thinking enabled",
+  );
+});
+
+await test("the CLI is unaffected when thinking is off", async () => {
+  skipUnlessProviderAvailable(PROVIDER);
+
+  const result = await runCLI(
+    [
+      "generate",
+      PROMPT,
+      "--provider",
+      PROVIDER,
+      "--model",
+      MODEL,
+      "--disableTools",
+    ],
+    { timeoutMs: 180_000 },
+  );
+
+  // The other direction: dropping the sampling knobs must happen only on
+  // thinking turns, never on ordinary ones.
+  assert(
+    result.exitCode === 0,
+    "the CLI exited non-zero on an ordinary generate with no thinking",
+  );
+});
+
+await test("an explicit temperature is dropped on a thinking stream turn", async () => {
+  skipUnlessProviderAvailable(PROVIDER);
+
+  // `stream()` spreads its options rather than filtering them through an
+  // allowlist, so thinkingConfig always reached the wire there — the drop was
+  // generate()-only. What the stream path DOES need covering is its own
+  // sampling guard: Anthropic rejects any temperature but 1 while thinking is
+  // set, so a caller supplying both must have the temperature dropped.
+  // Passing `temperature` explicitly is what makes this discriminate; without
+  // it there is nothing for the guard to remove and the case passes anywhere.
+  const { seen } = await observeRequests(async () => {
+    const result = await new NeuroLink().stream({
+      input: { text: PROMPT },
+      provider: PROVIDER,
+      model: MODEL,
+      maxTokens: 8000,
+      disableTools: true,
+      temperature: 0,
+      thinkingConfig: { enabled: true, budgetTokens: BUDGET },
+    });
+    let text = "";
+    for await (const chunk of result.stream) {
+      // The chunk union carries audio, TTS and no-output sentinel variants
+      // that have no `content`, so narrow before reading it. `tsx` erases
+      // types and would run this either way; `check:tools-tests` is what
+      // catches it.
+      if (
+        typeof chunk === "object" &&
+        chunk !== null &&
+        "content" in chunk &&
+        typeof chunk.content === "string"
+      ) {
+        text += chunk.content;
+      }
+    }
+    return text;
+  });
+
+  // PRECONDITION: a request must have been observed, and it must be a thinking
+  // turn — otherwise there is no guard under test and the assertion below
+  // would pass for the wrong reason.
+  assert(
+    seen.length > 0,
+    "precondition failed: no Messages request was observed on the stream path",
+  );
+  assert(
+    seen.some((r) => r.hasThinking),
+    "precondition failed: no stream request carried a thinking field, so the sampling guard was never exercised",
+  );
+
+  assert(
+    seen.every((r) => !r.hasTemperature),
+    "a thinking stream request still carried a temperature, which Anthropic rejects",
+  );
+});
+
+await runSuite();


### PR DESCRIPTION
## The defect

`generate()` accepts a `thinkingConfig` and the type documents it as the recommended way to switch extended thinking on. It never reached a provider.

`buildGenerateTextOptions` (`src/lib/neurolink.ts:5567`) converts the caller's public `GenerateOptions` into the internal `TextGenerationOptions` through an **explicit field-by-field allowlist**, and `thinkingConfig` was not in that list. Every provider gates thinking on `options.thinkingConfig`, so each one saw `undefined`. The request went out with no thinking block and nothing was raised to say the option had been discarded.

That function already carries a comment recording how `disableInternalFallback` was lost exactly this way. This is the second time the allowlist has silently swallowed a documented option.

## Proof — at the wire, red then green

The difference is only observable on the request, so that is where it is asserted.

| | release `3fdf80f1d` | this branch |
| --- | --- | --- |
| `thinkingConfig` reaches the request | ✗ **FAIL** — *no outbound request carried a thinking field* | ✓ PASS |
| omitting it sends no thinking field | ✓ | ✓ |
| CLI succeeds with thinking enabled | ✓ | ✓ |
| CLI unaffected with thinking off | ✓ | ✓ |
| | 1 passed, **1 failed** | **4 passed** |

Outbound request, captured on the built package:

```
before: keys=model,messages,max_tokens,system,tools          thinking=null
after:  keys=model,messages,max_tokens,system,tools,thinking thinking={"type":"enabled","budget_tokens":5000}
```

Only case 1 discriminates. The other three pass on **both** trees by design — they are regression guards, not proof.

The baseline is valid for this comparison: `10fa282f2` does not touch `neurolink.ts`, verified rather than assumed.

## A regression this fix caused, and fixes

Forwarding `thinkingConfig` is what first makes a `thinking` field reach the wire, and that immediately collided with a rule nothing had hit before: Anthropic rejects any temperature but 1 while thinking is enabled, and the CLI always sends a default temperature. The first version of this change turned a working `--thinking` invocation into a 400.

It was caught by running the **release build first** and finding it exited 0 — so the regression belonged to the fix, not the repository. Sampling knobs are now dropped whenever `thinking` is set, on both the generate and stream builders, and two CLI cases pin it.

## Why the suite does not assert on `result.reasoning`

The obvious assertion would fail forever. Whenever a proxy base URL is set — always true on the OAuth subscription path — the client requests the beta `redact-thinking-2026-02-12` (`anthropic/client.ts:878`), and Anthropic answers with thinking blocks whose text is redacted and whose signature is intact. Captured directly: `blockTypes=[thinking,text]`, thinking block `chars=0`, `hasSignature=true`. An empty `reasoning` is **correct** on that path.

The suite wraps `fetch` only to record what left the process. The call still goes through the real public `generate()` to the real provider; nothing is stubbed.

## Scope — deliberately narrow

`thinking`, `thinkingBudget` and `thinkingLevel` are documented in the type comments and in `CLAUDE.md`, but **none is declared on the public `GenerateOptions`**, so no caller can pass them through `generate()` at all. CLAUDE.md's own `thinkingLevel: "high"` example does not typecheck against the public API. Declaring them is a public-type decision, not a dropped-field fix, and is left out.

A caller's raw `providerOptions` is dropped by the same allowlist and is left alone for the same reason.

## Gates

`pnpm run check` 0 errors / 4844 files · eslint clean · prettier clean · pre-commit hook passed **without bypass** (it caught a real `no-useless-assignment` in the new test, which was fixed rather than skipped) · new suite registered as `test:thinking-config`.

**Correction (2026-09-11) — what that registration does and does not buy.** The script exists, but the suite appears in **no workflow**, so CI never runs it. The same is true of `test:matrix:cli`, `test:json-e2e` and the suite added in #1682. This repo's own `ci.yml` puts it exactly: *"a suite wired into nothing is documentation, not a test."* The red/green evidence above is real and was produced by running the suite against both trees by hand — but it will not catch a future regression until the suite is wired in. Live suites have one CI home, `live-matrix.yml`, which #1681 already modifies; the intent is one follow-up wiring the orphaned live suites in together once that lands, rather than scattering secret blocks across three PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Extended-thinking settings now reach Anthropic requests when configured through the SDK.
  - Thinking budgets are honored for standard and streaming responses.
  - Requests without thinking enabled continue to omit thinking configuration.

- **Bug Fixes**
  - Incompatible sampling parameters are excluded when extended thinking is enabled, avoiding request errors.

- **Tests**
  - Added coverage for SDK and CLI thinking configuration, including enabled, standard, and streaming request flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
