### PR TITLE
chore(ci): wire test:matrix:cli into the nightly live-matrix workflow

### DIFF
--- a/.github/workflows/live-matrix.yml
+++ b/.github/workflows/live-matrix.yml
@@ -41,8 +41,13 @@ jobs:
       - name: Build package
         run: pnpm run build
 
+      # Bounded because this job now runs two live sweeps back to back. The
+      # CLI harness already caps each child process, but nothing capped the
+      # step, and GitHub's default job ceiling is 360 minutes — long enough
+      # for one wedged provider to hold a nightly runner most of a day.
       - name: Live provider matrix sweep (self-gates cleanly when keys are absent)
         run: pnpm run test:matrix
+        timeout-minutes: 30
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -68,6 +73,51 @@ jobs:
           # The catalog derives <ID>_API_KEY, so Cloudflare is read as
           # CLOUDFLARE_API_KEY. This passed CLOUDFLARE_API_TOKEN, which
           # nothing reads — Cloudflare was silently skipped every night.
+          CLOUDFLARE_API_KEY: ${{ secrets.CLOUDFLARE_API_KEY }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
+          SAMBANOVA_API_KEY: ${{ secrets.SAMBANOVA_API_KEY }}
+          BASETEN_API_KEY: ${{ secrets.BASETEN_API_KEY }}
+          GMICLOUD_API_KEY: ${{ secrets.GMICLOUD_API_KEY }}
+          INCEPTION_LABS_API_KEY: ${{ secrets.INCEPTION_LABS_API_KEY }}
+          IO_INTELLIGENCE_API_KEY: ${{ secrets.IO_INTELLIGENCE_API_KEY }}
+          UPSTAGE_API_KEY: ${{ secrets.UPSTAGE_API_KEY }}
+          MANCER_API_KEY: ${{ secrets.MANCER_API_KEY }}
+          VOYAGE_API_KEY: ${{ secrets.VOYAGE_API_KEY }}
+          JINA_API_KEY: ${{ secrets.JINA_API_KEY }}
+          STABILITY_API_KEY: ${{ secrets.STABILITY_API_KEY }}
+          IDEOGRAM_API_KEY: ${{ secrets.IDEOGRAM_API_KEY }}
+          RECRAFT_API_KEY: ${{ secrets.RECRAFT_API_KEY }}
+          REPLICATE_API_TOKEN: ${{ secrets.REPLICATE_API_TOKEN }}
+
+      - name: Live provider matrix sweep — CLI (self-gates cleanly when keys are absent)
+        run: pnpm run test:matrix:cli
+        timeout-minutes: 30
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GOOGLE_AI_API_KEY: ${{ secrets.GOOGLE_AI_API_KEY }}
+          GOOGLE_SERVICE_ACCOUNT_KEY: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_KEY }}
+          GOOGLE_VERTEX_PROJECT: ${{ secrets.GOOGLE_VERTEX_PROJECT }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          SAGEMAKER_ENDPOINT: ${{ secrets.SAGEMAKER_ENDPOINT }}
+          AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
+          AZURE_OPENAI_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
+          MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
+          HUGGINGFACE_API_KEY: ${{ secrets.HUGGINGFACE_API_KEY }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+          COHERE_API_KEY: ${{ secrets.COHERE_API_KEY }}
+          FIREWORKS_API_KEY: ${{ secrets.FIREWORKS_API_KEY }}
+          PERPLEXITY_API_KEY: ${{ secrets.PERPLEXITY_API_KEY }}
+          XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
+          NVIDIA_NIM_API_KEY: ${{ secrets.NVIDIA_NIM_API_KEY }}
+          TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
+          # Same fix already applied to the SDK step above: the catalog derives
+          # <ID>_API_KEY, so Cloudflare must be passed as CLOUDFLARE_API_KEY,
+          # not CLOUDFLARE_API_TOKEN (nothing reads that name).
           CLOUDFLARE_API_KEY: ${{ secrets.CLOUDFLARE_API_KEY }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}


### PR DESCRIPTION
## The gap

`test:matrix:cli` has existed in `package.json:112` since the CLI mirror suite was written, and **no workflow has ever run it**. `live-matrix.yml` had exactly one test step, hard-coded to `pnpm run test:matrix`, so the SDK sweep received real provider credentials every night and its CLI twin received nothing. A grep for `test:matrix:cli` across `.github/workflows/` returned zero hits.

That matters because the two suites do not overlap. The CLI mirror exists to catch what the SDK sweep structurally cannot see — argument parsing, env var loading, exit codes, and bundling drift between the library and the binary. None of it was under test anywhere.

## Verification

A nightly workflow cannot be exercised by PR CI, so this was verified by live probe in both directions rather than by a repo test. Stating that plainly rather than implying coverage the change cannot have.

| Condition | Result |
| --- | --- |
| No credentials | `No providers selected.` · Passed 0 / Total 0 · `RESULT: PASS` · **exit 0** |
| Real `ANTHROPIC_API_KEY` | `✓ [anthropic] CLI generate`, `✓ [anthropic] CLI stream` · 2/2 · 8.83s |
| `grep -c 'run: pnpm run test:matrix'` | **1 → 2** |
| YAML | parses via js-yaml; steps 7 → 8; 86 → 130 lines |

The credential-free case is the one that matters for safety: a rotated-out key degrades to a clean pass, not a red nightly. The workflow is deliberately **not** a required check, so neither outcome can block a merge.

## Two costs, named

- The nightly job now sweeps every credentialed provider twice, and there is no job-level timeout today, so a wedged provider gets two chances per night to run long.
- The ~40-line secrets block is now duplicated in one file, so onboarding a provider must touch both copies.

## Deliberately not included

**41 of the 112 `test:*` scripts are invoked by no workflow at all**, and several are genuinely live-tier — `test:providers`, `test:new-providers`, all three `test:mcp:sdk/cli/http`, `test:observability`, `test:context`, `test:memory`, `test:rag`, `test:agents-live`, and `test:middleware` (explicitly held back for a Vertex-throttling bug).

`test:matrix:cli` is the only one with a one-to-one live sibling already receiving nightly secrets, which is what makes it a clean bounded fix. Each of the rest needs its own secret set, cost budget and skip-safety audit. Folding them in here would produce a change nobody could review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added live provider matrix coverage for CLI workflows across supported provider configurations.
  * Added live reasoning parity validation to verify consistent reasoning behavior.
  * Applied a 30-minute runtime limit to SDK and CLI provider matrix checks and a 15-minute limit to reasoning parity validation, helping prevent stalled test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->