### PR TITLE
fix(anthropic): send a string toolChoice instead of dropping it

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "test:matrix": "pnpm exec tsx test/continuous-test-suite-provider-matrix.ts",
     "test:matrix:cli": "pnpm exec tsx test/continuous-test-suite-provider-matrix-cli.ts",
     "test:thinking-config": "pnpm exec tsx test/continuous-test-suite-sdk-thinking-config.ts",
+    "test:anthropic-toolchoice": "pnpm exec tsx test/continuous-test-suite-anthropic-toolchoice.ts",
     "test:mcp:spans": "pnpm exec tsx test/continuous-test-suite-mcp-spans.ts",
     "test:mcp:infra": "pnpm exec tsx test/continuous-test-suite-mcp-infra.ts",
     "test:vendor-recovery": "pnpm exec tsx test/continuous-test-suite-native-vendor-recovery.ts",

--- a/src/lib/providers/anthropic/client.ts
+++ b/src/lib/providers/anthropic/client.ts
@@ -116,7 +116,10 @@ import {
   TimeoutError,
 } from "../../utils/timeout.js";
 import { raceWithAbort } from "../../utils/async/index.js";
-import { resolveToolChoice } from "../../utils/toolChoice.js";
+import {
+  normalizeResolvedToolChoice,
+  resolveToolChoice,
+} from "../../utils/toolChoice.js";
 import { emitToolEndFromStepFinish } from "../../utils/toolEndEmitter.js";
 import type { LanguageModel, Tool } from "../../types/index.js";
 import { NoOutputGeneratedError } from "../../utils/generationErrors.js";
@@ -1403,12 +1406,22 @@ export class AnthropicProvider extends BaseProvider {
         if (tools && tools.length === 0) {
           tools = undefined;
         }
-        let toolChoice = options.toolChoice
-          ? toolChoiceToAnthropic(
-              options.toolChoice.type === "tool"
-                ? { type: "tool", toolName: options.toolChoice.toolName }
-                : options.toolChoice.type,
-            )
+        // The value here has already been through `resolveToolChoice`
+        // upstream in `executeNativeGenerate`, so this layer translates
+        // rather than re-resolves — re-resolving would apply the auto/none
+        // defaulting twice, and `toolsRecord`/`shouldUseTools` are not in
+        // scope inside `getAISDKModel` in any case.
+        //
+        // Only the SHAPE varies, and reading `.type` off it was the bug:
+        // a bare `"required"` has no `.type`, so the translator received
+        // `undefined` and the field was dropped from the request entirely.
+        // Normalisation now lives in the shared util rather than being
+        // re-derived here, so this site cannot drift from its siblings again.
+        const normalisedToolChoice = normalizeResolvedToolChoice(
+          options.toolChoice,
+        );
+        let toolChoice = normalisedToolChoice
+          ? toolChoiceToAnthropic(normalisedToolChoice)
           : undefined;
 
         // JSON/structured output: Anthropic has no response_format — emulate

--- a/src/lib/utils/toolChoice.ts
+++ b/src/lib/utils/toolChoice.ts
@@ -13,3 +13,45 @@ export function resolveToolChoice(
 
   return options.toolChoice ?? "auto";
 }
+
+/**
+ * Normalise an already-resolved tool choice into the shape
+ * `toolChoiceToAnthropic` (and its peers) accept.
+ *
+ * A provider's model handle sees a value that has *already* been through
+ * `resolveToolChoice` upstream, so it must translate rather than re-resolve —
+ * re-resolving there would apply the `auto`/`none` defaulting twice, and the
+ * `tools`/`shouldUseTools` inputs it needs are not in scope at that layer
+ * anyway.
+ *
+ * What does vary is the shape. The value arrives either as a bare string
+ * (`"auto"` / `"none"` / `"required"`), as `{ type: "tool", toolName }`, or —
+ * on the native loop's tool-free re-ask — as an injected `{ type: "none" }`
+ * object. Reading `.type` off the string forms yields `undefined`, which is
+ * how string choices were silently dropped from the Anthropic generate
+ * request. This exists so that normalisation lives in one place instead of
+ * being re-derived at each call site.
+ */
+export function normalizeResolvedToolChoice(
+  value: unknown,
+): ToolChoice<Record<string, Tool>> | undefined {
+  if (typeof value === "string") {
+    return value as ToolChoice<Record<string, Tool>>;
+  }
+  if (value && typeof value === "object") {
+    const candidate = value as { type?: string; toolName?: string };
+    if (candidate.type === "tool") {
+      // A tool choice that names no tool cannot be honoured. Fall through to
+      // the provider default rather than emitting the bare string "tool",
+      // which is not one of the valid auto/none/required forms and would be
+      // rejected downstream.
+      return candidate.toolName
+        ? { type: "tool", toolName: candidate.toolName }
+        : undefined;
+    }
+    if (candidate.type) {
+      return candidate.type as ToolChoice<Record<string, Tool>>;
+    }
+  }
+  return undefined;
+}

--- a/test/continuous-test-suite-anthropic-toolchoice.ts
+++ b/test/continuous-test-suite-anthropic-toolchoice.ts
@@ -1,0 +1,250 @@
+#!/usr/bin/env tsx
+import "dotenv/config";
+
+/**
+ * Continuous Test Suite — string-form toolChoice reaches Anthropic, LIVE
+ *
+ * `toolChoice` accepts four shapes: the strings `"auto"`, `"none"`,
+ * `"required"`, and the object `{ type: "tool", toolName }`. On the Anthropic
+ * generate path the three string forms never reached the provider.
+ *
+ * `resolveToolChoice` returns a bare string for those cases, but the request
+ * builder read `.type` off the value before translating it. A string has no
+ * `.type`, so `toolChoiceToAnthropic` received `undefined`, returned
+ * `undefined`, and the field was dropped from the request entirely. A caller
+ * asking for a required tool silently got Anthropic's default `auto` — the
+ * model was free to answer without calling anything, and nothing was raised.
+ * The object form worked, because `.type === "tool"` is truthy.
+ *
+ * The translator itself was never at fault: it maps `"required"` to
+ * `{ type: "any" }` correctly. It simply was not being given the string. The
+ * streaming path already passed the value straight through, so this was a
+ * generate-only divergence from a sibling that had it right.
+ *
+ * WHY THIS ASSERTS ON THE REQUEST. Whether a model chooses to call a tool is
+ * its decision, so asserting "a tool was called" would be flaky in both
+ * directions — a model may call one without being forced, and may be forced
+ * and still produce a turn this suite reads as ambiguous. What the fix
+ * actually changes is the bytes we send. The suite therefore wraps `fetch` to
+ * record the outbound request. That is observation, not substitution: the call
+ * goes through the real public `generate()` to the real provider and the real
+ * response comes back. Nothing is stubbed.
+ *
+ * Only the first case discriminates. The other two pass on the release build
+ * as well and exist to catch this fix breaking the shape that already worked,
+ * or switching tool choice on for callers who never asked.
+ *
+ * `maxSteps` is capped deliberately: a forced tool choice with no cap does not
+ * reliably terminate, since the model can be compelled to call the tool again
+ * on every step. That is worth its own look and is not what this suite tests.
+ *
+ * Run: pnpm run build && npx tsx test/continuous-test-suite-anthropic-toolchoice.ts
+ */
+
+import { z } from "zod";
+import { NeuroLink, tool } from "../dist/index.js";
+import { defineSuite, assert } from "./helpers/harness.js";
+import { skipUnlessProviderAvailable } from "./helpers/skipIf.js";
+import { assertDistFresh } from "./helpers/distFreshness.js";
+
+assertDistFresh();
+
+const { test, runSuite } = defineSuite(
+  "Anthropic toolChoice passthrough (live)",
+);
+
+const PROVIDER = "anthropic";
+const MODEL = "claude-sonnet-4-5-20250929";
+const PROMPT = "What is the weather in Tokyo?";
+
+// The capture used to coerce every non-object `tool_choice` to `null`, which
+// made it blind to exactly the failure it is meant to watch for: a bare string
+// reaching the wire looked identical to no tool_choice at all. Record the raw
+// value and narrow at the point of use instead.
+type SeenRequest = {
+  toolChoice: Record<string, unknown> | string | null;
+};
+
+/** Narrow a captured tool_choice to its object form, or null. */
+const asObject = (
+  value: SeenRequest["toolChoice"],
+): Record<string, unknown> | null =>
+  value !== null && typeof value === "object" ? value : null;
+
+const weatherTool = () => ({
+  get_weather: tool({
+    description: "Returns the current weather for a city",
+    inputSchema: z.object({ city: z.string() }),
+    execute: async ({ city }: { city: string }) => ({ city, tempC: 22 }),
+  }),
+});
+
+/**
+ * Record every outbound Messages request while `run` executes, restoring the
+ * original `fetch` even if the call throws so one failure cannot leave a
+ * wrapped `fetch` behind for the next case.
+ */
+const observeRequests = async (
+  run: () => Promise<unknown>,
+): Promise<SeenRequest[]> => {
+  const seen: SeenRequest[] = [];
+  const original = globalThis.fetch;
+  globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+    if (String(input).includes("/v1/messages")) {
+      let body: Record<string, unknown>;
+      try {
+        body = JSON.parse(String(init?.body ?? "{}")) as Record<
+          string,
+          unknown
+        >;
+      } catch {
+        body = {};
+      }
+      const choice = body.tool_choice;
+      seen.push({
+        toolChoice:
+          choice === undefined || choice === null
+            ? null
+            : (choice as Record<string, unknown> | string),
+      });
+    }
+    return original(input, init);
+  };
+  try {
+    await run();
+    return seen;
+  } finally {
+    globalThis.fetch = original;
+  }
+};
+
+await test('the string form "required" reaches the provider', async () => {
+  skipUnlessProviderAvailable(PROVIDER);
+
+  const seen = await observeRequests(() =>
+    new NeuroLink().generate({
+      input: { text: PROMPT },
+      provider: PROVIDER,
+      model: MODEL,
+      maxTokens: 2000,
+      maxSteps: 2,
+      toolChoice: "required",
+      tools: weatherTool(),
+    }),
+  );
+
+  // PRECONDITION: an assertion about a request's contents is vacuous if no
+  // request was captured.
+  assert(
+    seen.length > 0,
+    "precondition failed: no Messages request was observed",
+  );
+
+  // The regression. Pre-fix the builder read `.type` off the string, the
+  // translator got undefined, and the field never left the process.
+  assert(
+    seen.some((r) => r.toolChoice !== null),
+    "no outbound request carried a tool_choice, so the string form never reached the provider",
+  );
+  assert(
+    seen.some((r) => asObject(r.toolChoice)?.type === "any"),
+    'the string form did not translate to Anthropic\'s "any" tool choice',
+  );
+});
+
+await test("the object form still reaches the provider unchanged", async () => {
+  skipUnlessProviderAvailable(PROVIDER);
+
+  const seen = await observeRequests(() =>
+    new NeuroLink().generate({
+      input: { text: PROMPT },
+      provider: PROVIDER,
+      model: MODEL,
+      maxTokens: 2000,
+      maxSteps: 2,
+      toolChoice: { type: "tool", toolName: "get_weather" },
+      tools: weatherTool(),
+    }),
+  );
+
+  assert(
+    seen.length > 0,
+    "precondition failed: no Messages request was observed",
+  );
+
+  // Control: this shape worked before the fix and must keep working.
+  assert(
+    seen.some(
+      (r) =>
+        asObject(r.toolChoice)?.type === "tool" &&
+        asObject(r.toolChoice)?.name === "get_weather",
+    ),
+    "the object form no longer names the requested tool on the wire",
+  );
+});
+
+await test('a tool choice naming no tool sends no tool_choice rather than a bare "tool"', async () => {
+  skipUnlessProviderAvailable(PROVIDER);
+
+  const seen = await observeRequests(() =>
+    new NeuroLink().generate({
+      input: { text: PROMPT },
+      provider: PROVIDER,
+      model: MODEL,
+      maxTokens: 2000,
+      maxSteps: 2,
+      // Malformed on purpose: `type: "tool"` with no `toolName`. Not
+      // reachable from a well-typed caller, but normalisation reads an
+      // `unknown`, so the shape has to be handled rather than assumed away.
+      toolChoice: { type: "tool" } as unknown as never,
+      tools: weatherTool(),
+    }),
+  );
+
+  assert(
+    seen.length > 0,
+    "precondition failed: no Messages request was observed",
+  );
+
+  // `"tool"` is not one of Anthropic's valid auto/none/required strings, so
+  // forwarding it would be worse than dropping it: the request is rejected
+  // outright instead of falling back to the default.
+  assert(
+    seen.every((r) => r.toolChoice !== "tool"),
+    "a request carried the bare string tool_choice",
+  );
+  assert(
+    seen.every((r) => r.toolChoice === null),
+    "a nameless tool choice still reached the wire",
+  );
+});
+
+await test("omitting toolChoice sends no tool_choice", async () => {
+  skipUnlessProviderAvailable(PROVIDER);
+
+  const seen = await observeRequests(() =>
+    new NeuroLink().generate({
+      input: { text: PROMPT },
+      provider: PROVIDER,
+      model: MODEL,
+      maxTokens: 2000,
+      maxSteps: 2,
+      tools: weatherTool(),
+    }),
+  );
+
+  assert(
+    seen.length > 0,
+    "precondition failed: no Messages request was observed",
+  );
+
+  // Control in the other direction: normalising the value must not invent a
+  // tool choice for callers who never supplied one. Anthropic defaults to
+  // auto when the field is absent, which is the behaviour to preserve.
+  assert(
+    seen.every((r) => r.toolChoice === null),
+    "a request carried a tool_choice even though the caller supplied none",
+  );
+});
+
+await runSuite();


### PR DESCRIPTION
## The defect

`toolChoice` accepts four shapes: the strings `"auto"`, `"none"`, `"required"`, and the object `{ type: "tool", toolName }`. **On the Anthropic generate path the three string forms never reached the provider.**

`resolveToolChoice` (`utils/toolChoice.ts:14`) returns a bare string for those cases, but the request builder read `.type` off the value before translating it:

```ts
options.toolChoice.type === "tool"
  ? { type: "tool", toolName: options.toolChoice.toolName }
  : options.toolChoice.type          // a string has no .type → undefined
```

So `toolChoiceToAnthropic` was handed `undefined`, returned `undefined`, and the field was omitted from the request. A caller asking for a **required** tool silently got Anthropic's default `auto` — the model free to answer without calling anything, and nothing raised to say the option had been discarded.

The translator was never at fault. It maps `"required"` → `{ type: "any" }` correctly one screen up; it simply was never given the string.

## A sibling already had it right

The streaming path passes the value straight through:

```ts
toolChoiceToAnthropic(resolveToolChoice(options, toolsRecord, shouldUseTools))
```

This was a generate-only divergence. The two now agree. The object branch stays explicit so a V3-shaped `{ type: "required" }` also normalises to the string the translator expects.

## Proof — at the wire, red then green

| case | release `10fa282f2` | this branch |
| --- | --- | --- |
| `"required"` reaches the provider | ✗ **FAIL** — *no outbound request carried a tool_choice* | ✓ `{type:"any"}` |
| object form unchanged | ✓ | ✓ |
| omitting it sends no `tool_choice` | ✓ | ✓ |
| | 2 passed, **1 failed** | **3 passed** |

**Only the first case discriminates.** The other two pass on the release build as well — they are there to catch this fix breaking the object form that already worked, or inventing a tool choice for callers who supplied none. Stating that plainly rather than presenting 3/3 as though all three were evidence.

### Why it asserts on the request, not on tool usage

Whether a model calls a tool is its own decision, so asserting "a tool was called" would be flaky in both directions. What this fix changes is the bytes we send. The suite wraps `fetch` to record the outbound request and otherwise drives the real public `generate()` against the real provider — nothing is stubbed, the real response comes back.

## Noted, not fixed here

A forced tool choice with **no `maxSteps` cap does not reliably terminate** — the model can be compelled to call the tool again on every step. The suite caps it deliberately. That behaviour deserves its own look and is out of scope.

## Gates

`pnpm run check` 0 errors · `pnpm run check:tools-tests` 0 errors · `build` clean · `docs/api` drift 0 (the change is inside a function body, no signature change, so the docs-site artifacts correctly need no regeneration) · pre-commit hook passed without bypass · registered nothing new in `package.json` beyond the suite file itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Anthropic tool selection so string choices such as `"auto"`, `"none"`, and `"required"` are honored correctly.
  - Ensured object-based tool choices continue to pass through as expected.
  - Prevented incomplete tool selections from being sent as invalid requests.

- **Tests**
  - Added coverage for string and object tool choices, omitted settings, and incomplete tool selections in generated Anthropic requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->