### PR TITLE
test(cli-matrix): guard the CLI matrix suite against a stale dist

### DIFF
--- a/test/continuous-test-suite-provider-matrix-cli.ts
+++ b/test/continuous-test-suite-provider-matrix-cli.ts
@@ -27,6 +27,18 @@ import {
   isExpectedProviderError,
 } from "./helpers/harness.js";
 import { PROVIDERS, hasProviderEnv } from "./helpers/providerMatrix.js";
+import { assertDistFresh } from "./helpers/distFreshness.js";
+
+// This suite spawns `dist/cli/index.js`, so a stale dist means it silently
+// exercises an old binary — and the whole point of the suite is to catch
+// CLI-only drift between the library and that binary, which is exactly what a
+// stale dist hides. Its SDK sibling (continuous-test-suite-provider-matrix.ts)
+// has always guarded this; this one did not.
+// The CLI bundle is named explicitly: the directory-wide check takes the
+// newest mtime anywhere under dist/, so a freshly written dist/index.js would
+// keep it quiet while dist/cli/index.js — the thing this suite actually
+// spawns — stayed stale from a partial build.
+assertDistFresh({ entrypoints: ["dist/cli/index.js"] });
 
 const { test, runSuite, opts } = defineSuite(
   "Provider Capability Matrix (CLI)",
@@ -61,6 +73,16 @@ type CliResult = {
   timedOut: boolean;
 };
 
+/**
+ * Deliberately NOT `runCLI` from helpers/harness.js. That helper returns
+ * `ProcessResult`, which is `{ stdout, stderr, exitCode }` and has no way to
+ * say a run was killed for exceeding its deadline. This suite needs that
+ * distinction: a provider that hangs is a SKIP in a nightly sweep, not a
+ * failure, and folding it into a plain non-zero exit would turn every wedged
+ * upstream into red. Deduplicating these means teaching `runCommand` to
+ * surface a timeout flag — a shared-helper change affecting every suite that
+ * uses it, not a local import swap.
+ */
 function runCli(args: string[]): Promise<CliResult> {
   return new Promise((resolve) => {
     const child = spawn("node", [CLI_BIN, ...args], {
@@ -109,6 +131,26 @@ function skipIfProviderError(err: unknown): never {
   throw err as Error;
 }
 
+/**
+ * WHY THE PAYLOAD IN THE FINAL THROW IS SAFE HERE, AND WHAT WOULD BREAK IT.
+ *
+ * CLAUDE.md warns that quoting provider output into a thrown message can turn
+ * a real failure into a silent SKIP, because `isExpectedProviderError()` is
+ * applied to the message text. That hazard is real in general and does not
+ * bite here, for two reasons worth stating so nobody "fixes" it by guesswork:
+ *
+ *   1. The check below runs first on the FULL `combined` text. By the time the
+ *      payload is embedded, the predicate has already answered false for a
+ *      superset of what gets embedded.
+ *   2. `slice()` produces a prefix, and none of the predicate's patterns use
+ *      an end anchor or a lookahead, so truncation can only remove a match,
+ *      never create one. Verified: a marker past 400 chars matches the full
+ *      string and not the slice — the safe direction.
+ *
+ * What would break it: a future pattern anchored with `$`, or embedding text
+ * the earlier check never saw. If either happens, drop the payload and report
+ * byte counts instead.
+ */
 function classifyCliFailure(args: string[], result: CliResult): never {
   const combined = `${result.stdout}\n${result.stderr}`;
   if (result.timedOut) {

--- a/test/helpers/distFreshness.ts
+++ b/test/helpers/distFreshness.ts
@@ -69,23 +69,42 @@ function describeAge(mtimeMs: number): string {
   return hours < 48 ? `${hours}h ago` : `${Math.round(hours / 24)}d ago`;
 }
 
-let checked = false;
+/** Memoised directory walk; the mtimes cannot change usefully mid-run. */
+let cachedWalk: { newestSrc: number; newestDist: number } | null = null;
+
+export type DistFreshnessOptions = {
+  /**
+   * Repo-relative bundles that must individually be newer than `src/`.
+   *
+   * The directory-wide comparison below takes the newest mtime found ANYWHERE
+   * under `dist/`, so one freshly written file satisfies it for the whole
+   * tree. That is the right default — it catches the case that actually bites,
+   * a `dist/` left over from another checkout — but it cannot see a PARTIAL
+   * build, where one bundle is rewritten and another is not. A suite that
+   * spawns `dist/cli/index.js` can therefore be handed a stale CLI while a
+   * fresh `dist/index.js` keeps the guard quiet.
+   *
+   * Naming an entrypoint here checks that file's own mtime as well.
+   */
+  entrypoints?: readonly string[];
+};
 
 /**
  * Throw when `dist/` is missing or older than the newest file in `src/`.
  *
- * Idempotent: only the first call does the walk, so suites that call it from
- * several places pay for it once.
+ * The expensive directory walk runs once per process and is reused; the
+ * per-entrypoint checks are a `stat` each and run on every call, so a suite
+ * naming a bundle is never silently skipped because another suite called this
+ * first.
  *
  * Set `NEUROLINK_SKIP_DIST_FRESHNESS_CHECK=1` to bypass — intended for CI jobs
  * that build in a separate step where mtimes may not survive artifact
  * restoration, not for local use.
  */
-export function assertDistFresh(): void {
-  if (checked || process.env.NEUROLINK_SKIP_DIST_FRESHNESS_CHECK === "1") {
+export function assertDistFresh(options: DistFreshnessOptions = {}): void {
+  if (process.env.NEUROLINK_SKIP_DIST_FRESHNESS_CHECK === "1") {
     return;
   }
-  checked = true;
 
   const distDir = join(REPO_ROOT, "dist");
   if (!existsSync(join(distDir, "index.js"))) {
@@ -95,10 +114,15 @@ export function assertDistFresh(): void {
     );
   }
 
-  // node_modules is not under src/, but skip defensively in case of nesting.
-  const skip = new Set(["node_modules", ".DS_Store"]);
-  const newestSrc = newestMtimeMs(join(REPO_ROOT, "src"), skip);
-  const newestDist = newestMtimeMs(distDir, skip);
+  if (!cachedWalk) {
+    // node_modules is not under src/, but skip defensively in case of nesting.
+    const skip = new Set(["node_modules", ".DS_Store"]);
+    cachedWalk = {
+      newestSrc: newestMtimeMs(join(REPO_ROOT, "src"), skip),
+      newestDist: newestMtimeMs(distDir, skip),
+    };
+  }
+  const { newestSrc, newestDist } = cachedWalk;
 
   if (newestSrc > newestDist) {
     throw new Error(
@@ -108,5 +132,25 @@ export function assertDistFresh(): void {
         `failures that look exactly like real regressions.\n` +
         `Run \`pnpm run build\` first.`,
     );
+  }
+
+  for (const relative of options.entrypoints ?? []) {
+    const full = join(REPO_ROOT, relative);
+    if (!existsSync(full)) {
+      throw new Error(
+        `This suite drives ${relative}, but that file does not exist.\n` +
+          "Run `pnpm run build` first.",
+      );
+    }
+    const { mtimeMs } = statSync(full);
+    if (newestSrc > mtimeMs) {
+      throw new Error(
+        `${relative} is stale — src/ has changed since that bundle was built ` +
+          `(newest src ${describeAge(newestSrc)}, ${relative} ${describeAge(mtimeMs)}).\n` +
+          `The directory-wide check passed because some other file under dist/ is ` +
+          `newer, which is exactly how a partial build hides.\n` +
+          `Run \`pnpm run build\` first.`,
+      );
+    }
   }
 }


### PR DESCRIPTION
## The defect

`test/continuous-test-suite-provider-matrix-cli.ts` spawns `dist/cli/index.js` for every provider in the matrix, and never called `assertDistFresh()`. Its SDK sibling, `continuous-test-suite-provider-matrix.ts`, always has.

So a `dist/` left over from an earlier checkout made this suite exercise an old binary silently. That is particularly bad here: the suite exists to catch drift between the library and the shipped binary, which is exactly what a stale `dist/` conceals. Failures would read as ordinary provider regressions with nothing indicating the artifact under test was not the working tree — the failure mode `distFreshness.ts`'s own header describes as "worse than a hard failure".

## Red / green

No provider calls on either side: `--provider=__none__` selects nothing, so the run reaches the guard and then stops.

| tree | `dist/` | result |
|---|---|---|
| release | made stale | **exit 0** — proceeds silently |
| this branch | made stale | **exit 1** — `dist/ is stale — src/ has changed since the last build` |
| this branch | fresh | **exit 0** — guard does not false-positive |

The third row carries as much weight as the first two. `assertDistFresh` compares mtimes, so a guard that fired on a healthy tree would be worse than no guard. Both trees' mtimes were restored afterwards and re-verified at exit 0.

## Two claims investigated and deliberately NOT changed

Both were on my own to-do list for this file. Neither survived checking, so both are recorded as comments in place rather than acted on — the point is that the next reader does not "fix" them by guesswork.

**The 400-char payload in `classifyCliFailure`'s final throw is not the hazard it looks like.** `CLAUDE.md` warns that quoting provider output into a thrown message lets `isExpectedProviderError()` turn a real failure into a silent skip. That is sound in general and unreachable here: the check immediately above already applies the same predicate to the **full** combined output, so by the time the payload is embedded the answer is known false for a superset of it; and `slice()` yields a prefix while no pattern in the predicate uses an end anchor or a lookahead, so truncation can only remove a match, never create one. Verified directly — a marker placed past 400 characters matches the full string and not the slice, which is the safe direction. The comment names the thing that would break this: a future `$`-anchored pattern.

**Swapping the hand-rolled `runCli` for `runCLI` from `helpers/harness.js` would be a regression.** `ProcessResult` is `{ stdout, stderr, exitCode }` and has no way to express "killed for exceeding its deadline". This suite needs that: a provider that hangs is a SKIP in a nightly sweep, not a failure, and folding it into a plain non-zero exit would turn every wedged upstream into red. Deduplicating them properly means teaching `runCommand` to surface a timeout flag, which touches every suite that uses it — a separate change with a much wider blast radius.

## Scope

One file, test-only. No `src/` change, so `docs/api` and the `docs-site` artifacts are untouched and unaffected — confirmed by `git status` over both paths after the edit. `check:tools-tests` and `lint` both pass.

## What this does not do

This suite still runs in no workflow. Registering a `test:` script does not make CI run it, and that gap is tracked across all the orphaned live suites in #1684 — so this guard protects anyone running the suite by hand, which is currently everyone who runs it at all.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * The CLI provider matrix now verifies that the bundled CLI is up to date before running tests.
  * Improved freshness checks detect missing or outdated CLI entry points, helping catch incomplete builds earlier.
  * Added documentation covering timeout handling and the safety considerations for including CLI output in test failure messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->