### PR TITLE
chore(ci): run the required checks on stacked pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,17 @@ name: CI
 on:
   push:
     branches: [release]
+  # Deliberately UNFILTERED by base branch. Every one of the four required
+  # contexts this repository gates on — test, provider-safety-net,
+  # security-suites, build-check — is a job in THIS file, so a base filter
+  # here decides whether they exist at all, not merely whether they pass.
+  # Scoped to [release], a stacked pull request (one based on another feature
+  # branch so it can build on unmerged work) had NONE of them created. That
+  # does not read as a failure: a check that was never created is reported as
+  # missing, which looks like "still queued" forever, and the pull request can
+  # never go green no matter how good the change is. PR #1670 sat at 1 of 5
+  # required checks for exactly this reason.
   pull_request:
-    branches: [release]
 
 # Cancel a run that a newer push to the same ref has superseded. Without this
 # an amend-and-force-push — routine under the single-commit-per-branch policy —

--- a/.github/workflows/single-commit-enforcement.yml
+++ b/.github/workflows/single-commit-enforcement.yml
@@ -3,8 +3,13 @@ name: Single Commit Per Branch Enforcement
 on:
   push:
     branches-ignore: [release, main, develop]
+  # Unfiltered by base branch, for the same reason as ci.yml: the
+  # pull_request path below is the only one that knows the PR's real base
+  # (github.base_ref). Filtered to [release, main], a stacked PR fell through
+  # to the push path, which assumed origin/release and therefore counted the
+  # PARENT branch's commit as one of this branch's own — reporting two commits
+  # for a single-commit PR and failing a policy it had not broken.
   pull_request:
-    branches: [release, main]
     types: [opened, synchronize, reopened]
 
 concurrency:
@@ -43,9 +48,13 @@ jobs:
           HEAD_REPO_ID: ${{ github.event.pull_request.head.repo.id }}
           BASE_REPO_ID: ${{ github.event.repository.id }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          # Needed by the `gh pr list` base lookup on the push path below.
+          GH_TOKEN: ${{ github.token }}
         run: |
           # Determine the base branch and current branch
           if [ "$EVENT_NAME" = "pull_request" ]; then
+            # Authoritative: the event carries the PR's real base branch.
+            BASE_KNOWN=true
             BASE_BRANCH="origin/$BASE_REF"
             BRANCH_NAME="$HEAD_REF"
             
@@ -70,7 +79,56 @@ jobs:
               CURRENT_BRANCH="origin/$HEAD_REF"
             fi
           else
+            # A push event carries no base branch. Assuming release is right
+            # for the ordinary case and wrong for a stacked branch, where it
+            # counts the parent's commits as this branch's own. So the base is
+            # read from the branch's open pull request when exactly one can be
+            # identified, and treated as UNKNOWN otherwise — never guessed into
+            # a verdict.
+            BASE_KNOWN=false
             BASE_BRANCH="origin/release"
+
+            # Three outcomes have to stay distinguishable here, because two of
+            # them look identical if you only check whether the output is
+            # empty: the lookup succeeded and found one PR, it succeeded and
+            # found none, or it FAILED. Swallowing a failure with `|| true`
+            # turns an auth or API error into "no pull request", which then
+            # silently produces a policy verdict measured against the wrong
+            # base. So the exit status is captured separately from the output.
+            PR_LOOKUP_OK=true
+            PR_JSON=$(gh pr list --head "$REF_NAME" --state open \
+              --json headRefName,baseRefName 2>/dev/null) || PR_LOOKUP_OK=false
+
+            if [ "$PR_LOOKUP_OK" != "true" ]; then
+              echo "⚠️  Could not query pull requests for this branch (auth or"
+              echo "    API failure). Treating the base as unknown rather than"
+              echo "    assuming release, so no verdict is reached on a base"
+              echo "    that was never confirmed."
+            else
+              # `--head` filters by name and can match a PREFIX, and a branch
+              # may legitimately have several open pull requests that share it
+              # while targeting different bases. Either way `.[0]` would pick
+              # one arbitrarily, so require exactly one EXACT head match.
+              MATCHES=$(printf '%s' "$PR_JSON" \
+                | jq --arg ref "$REF_NAME" '[.[] | select(.headRefName == $ref)]')
+              MATCH_COUNT=$(printf '%s' "$MATCHES" | jq 'length')
+
+              if [ "$MATCH_COUNT" -eq 1 ]; then
+                BASE_KNOWN=true
+                BASE_BRANCH="origin/$(printf '%s' "$MATCHES" | jq -r '.[0].baseRefName')"
+                echo "🔗 Resolved base branch from the branch's one open PR: $BASE_BRANCH"
+              elif [ "$MATCH_COUNT" -eq 0 ]; then
+                echo "ℹ️  No open pull request for this branch yet, so the real"
+                echo "    base is unknown. Assuming release for reporting, but"
+                echo "    enforcement is deferred to the pull_request run."
+              else
+                echo "⚠️  $MATCH_COUNT open pull requests share this head branch"
+                echo "    while targeting different bases, so the intended base"
+                echo "    is ambiguous. Treating it as unknown; each pull"
+                echo "    request is still enforced against its own base by the"
+                echo "    pull_request run."
+              fi
+            fi
             CURRENT_BRANCH="HEAD"
             BRANCH_NAME="$REF_NAME"
           fi
@@ -86,6 +144,7 @@ jobs:
           COMMIT_COUNT=$(git rev-list --count $CURRENT_BRANCH ^$BASE_BRANCH 2>/dev/null || echo "0")
 
           echo "commits_ahead=$COMMIT_COUNT" >> $GITHUB_OUTPUT
+          echo "base_known=$BASE_KNOWN" >> $GITHUB_OUTPUT
           echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
           echo "base_branch=$BASE_BRANCH" >> $GITHUB_OUTPUT
 
@@ -112,6 +171,21 @@ jobs:
             echo "commit_hash=$COMMIT_HASH" >> $GITHUB_OUTPUT
             echo "commit_author=$COMMIT_AUTHOR" >> $GITHUB_OUTPUT
             
+          elif [ "$BASE_KNOWN" != "true" ]; then
+            # More than one commit ahead of a base we GUESSED. On a stacked
+            # branch that is the correct and expected state: the extra commits
+            # belong to the parent branch, not to this one. Failing here would
+            # report a policy violation the branch has not committed, which is
+            # exactly what this workflow used to do to every stacked PR on its
+            # first push — before its pull request existed to be read.
+            echo "⚠️  $COMMIT_COUNT commits ahead of the ASSUMED base"
+            echo "    ($BASE_BRANCH), and no open pull request was found to"
+            echo "    confirm the real one. Not treating this as a violation."
+            echo "    The pull_request run enforces the policy against the"
+            echo "    branch's actual base, so nothing merges unchecked."
+            echo "status=base_unknown" >> $GITHUB_OUTPUT
+            echo "📋 Commits ahead of the assumed base:"
+            git log --oneline $CURRENT_BRANCH ^$BASE_BRANCH
           else
             echo "❌ POLICY VIOLATION: Branch contains $COMMIT_COUNT commits"
             echo "status=violation" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## The problem

A pull request based on another feature branch — a *stacked* PR, opened so
dependent work can proceed before its parent merges — **cannot go green in this
repository today.** Not "tends to fail": cannot.

Every one of the four required status contexts is a job in a single file:

| required context | defined in |
| --- | --- |
| `test` | `.github/workflows/ci.yml` |
| `provider-safety-net` | `.github/workflows/ci.yml` |
| `security-suites` | `.github/workflows/ci.yml` |
| `build-check` | `.github/workflows/ci.yml` |

That file's trigger was `pull_request: branches: [release]`. A base-branch filter
there decides whether those checks are **created**, not whether they pass. So a
stacked PR had none of them.

And a check that was never created does not report as failing — it reports as
*missing*, which is indistinguishable from "still queued". This is the exact
trap `CLAUDE.md` already documents under *"A check that has not appeared has not
passed"*.

**Live evidence:** PR #1670 has sat at **1 of 5** required contexts since it was
opened. Not one of them is red. Four were never created.

## The second, independent failure

`single-commit-enforcement.yml` failed the same PRs a different way. Its
`pull_request` trigger was scoped to `[release, main]`, so a stacked PR fell
through to the **push-event** path — which hardcoded `origin/release` as the
base:

```bash
else
  BASE_BRANCH="origin/release"
```

Counting commits from `origin/release` on a branch stacked on another feature
branch includes the **parent's** commit. A single-commit PR was reported as
carrying two, and failed a policy it had not broken.

## The change

Both `pull_request` triggers are now unfiltered by base branch.

- The pull-request path in `single-commit-enforcement.yml` already resolved the
  real base from `github.base_ref`, so it needed no other change — it simply was
  never reached.
- The push path now asks for the branch's open PR and uses its base when there
  is one, falling back to `origin/release` when there is not, so a branch pushed
  before its PR exists behaves exactly as before.
- `push` remains scoped to `release` in `ci.yml`. Only pull-request handling
  changed.

## Verification

The before state is on the record: #1670, 1 of 5 contexts, four never created.

The after state is what this PR is for. Because `pull_request` runs resolve the
workflow from the merge of head into base, a PR **stacked on this branch** picks
up the new trigger and is the direct proof. I will open one against this branch
and post the context list here rather than assert the outcome — the whole point
of this change is that a missing check is not a passing one, and it would be
incoherent to claim success without showing the five contexts appear.

## Why this matters beyond #1670

Two items in the close-out backlog are sequenced purely because stacking does
not work: the stdio SIGKILL escalation that builds on #1683, and the issue-1684
CI wiring that builds on #1681. Neither has a technical reason to wait for a
merge; both were waiting on this.

## Risk

CI now runs on pull requests to any base branch, which costs runner minutes on
stacked PRs that previously got none. That is the intended trade: the
alternative is that stacked PRs remain unmergeable by construction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Pull request checks now run for pull requests targeting any branch, including stacked pull requests.
  - Validation now evaluates changes against the pull request’s actual base branch.
  - Push-based validation identifies the associated open pull request when available, providing more accurate checks across different branch workflows.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->