### PR TITLE
fix(openai): stop rejecting schemas that carry an optional field

### DIFF
--- a/src/lib/providers/openaiChatCompletionsClient.ts
+++ b/src/lib/providers/openaiChatCompletionsClient.ts
@@ -475,6 +475,138 @@ export const v3ToolChoiceToOpenAI = (
   }
 };
 
+/**
+ * OpenAI's strict structured-output mode rejects a schema unless every object
+ * node carries `additionalProperties: false` AND lists every one of its
+ * properties in `required` — recursively, including through array `items`.
+ * A plain JSON Schema satisfies neither, so sending one with `strict: true`
+ * fails the request outright rather than degrading.
+ *
+ * Adding `additionalProperties: false` is safe: it forbids keys the caller
+ * never asked for, which strict mode would forbid anyway. Filling in
+ * `required` is NOT safe — it would silently make the caller's optional
+ * fields mandatory. So when a schema still has optional properties after
+ * normalisation, the request drops to `strict: false`, which OpenAI accepts
+ * and which honours optionality. Callers whose schemas are already strict-
+ * compatible keep the stronger guarantee.
+ */
+// `properties` and `$defs` are MAPS of schemas, not schemas — recursing into
+// them as if they were nodes silently skips every child, which is exactly the
+// bug that let a nested object through without `additionalProperties: false`.
+const SCHEMA_MAPS = [
+  "properties",
+  "patternProperties",
+  "$defs",
+  "definitions",
+] as const;
+const SCHEMA_NODES = [
+  "items",
+  "prefixItems",
+  "anyOf",
+  "oneOf",
+  "allOf",
+  "not",
+  "then",
+  "else",
+] as const;
+
+// OpenAI's strict mode does not accept these composition keywords. A schema
+// carrying one cannot be sent with `strict: true` at all, so it is not merely
+// "not yet normalised" — it must drop to non-strict, where the schema is
+// honoured as written.
+const STRICT_UNSUPPORTED = ["allOf", "not", "if", "then", "else"] as const;
+
+const mapValues = (
+  obj: unknown,
+  fn: (v: unknown) => unknown,
+): Record<string, unknown> =>
+  Object.fromEntries(
+    Object.entries((obj ?? {}) as Record<string, unknown>).map(([k, v]) => [
+      k,
+      fn(v),
+    ]),
+  );
+
+const withClosedObjects = (node: unknown): unknown => {
+  if (Array.isArray(node)) {
+    return node.map(withClosedObjects);
+  }
+  if (!node || typeof node !== "object") {
+    return node;
+  }
+  const next: Record<string, unknown> = {
+    ...(node as Record<string, unknown>),
+  };
+  for (const key of SCHEMA_MAPS) {
+    if (key in next) {
+      next[key] = mapValues(next[key], withClosedObjects);
+    }
+  }
+  for (const key of SCHEMA_NODES) {
+    if (key in next) {
+      next[key] = withClosedObjects(next[key]);
+    }
+  }
+  // A schema-valued `additionalProperties` is itself a schema (the index/value
+  // pattern) and its nested objects need closing too. A boolean one is a flag
+  // and must be left exactly as the caller wrote it.
+  if (
+    next.additionalProperties &&
+    typeof next.additionalProperties === "object"
+  ) {
+    next.additionalProperties = withClosedObjects(next.additionalProperties);
+  } else if (next.type === "object" && !("additionalProperties" in next)) {
+    // Closed whether or not it declares `properties`: strict mode requires the
+    // key on EVERY object, including an empty one.
+    next.additionalProperties = false;
+  }
+  return next;
+};
+
+/**
+ * True when the schema can legally be sent with `strict: true`: every object
+ * node lists all of its properties as required, every object is closed, and
+ * no composition keyword OpenAI rejects appears anywhere.
+ *
+ * Deliberately conservative — a false negative costs only the stronger
+ * guarantee, while a false positive costs the whole request.
+ */
+const satisfiesStrictRequired = (node: unknown): boolean => {
+  if (Array.isArray(node)) {
+    return node.every(satisfiesStrictRequired);
+  }
+  if (!node || typeof node !== "object") {
+    return true;
+  }
+  const rec = node as Record<string, unknown>;
+  if (STRICT_UNSUPPORTED.some((k) => k in rec)) {
+    return false;
+  }
+  if (rec.type === "object") {
+    if (rec.additionalProperties !== false) {
+      return false;
+    }
+    const names = Object.keys(
+      (rec.properties ?? {}) as Record<string, unknown>,
+    );
+    const required = Array.isArray(rec.required)
+      ? (rec.required as unknown[])
+      : [];
+    if (names.some((n) => !required.includes(n))) {
+      return false;
+    }
+  }
+  const mapsOk = SCHEMA_MAPS.filter((k) => k in rec).every((k) =>
+    Object.values((rec[k] ?? {}) as Record<string, unknown>).every(
+      satisfiesStrictRequired,
+    ),
+  );
+  const nodesOk = SCHEMA_NODES.filter((k) => k in rec).every((k) =>
+    satisfiesStrictRequired(rec[k]),
+  );
+  return mapsOk && nodesOk;
+};
+
 export const v3ResponseFormatToOpenAI = (rf: {
   type: "text" | "json";
   schema?: Record<string, unknown>;
@@ -487,13 +619,38 @@ export const v3ResponseFormatToOpenAI = (rf: {
   if (!rf.schema) {
     return { type: "json_object" };
   }
+  // Mutate as little as possible, in this order:
+  //
+  //   1. already strict-legal  -> send it UNTOUCHED with strict: true
+  //   2. legal once closed     -> send the closed copy with strict: true
+  //   3. neither               -> send it UNTOUCHED with strict: false
+  //
+  // Case 3 is why closure is not applied unconditionally. Non-strict mode
+  // honours the schema exactly as written, so injecting
+  // `additionalProperties: false` there would silently change the caller's
+  // contract — and for a composition it can make the schema unsatisfiable:
+  // closing two `allOf` members that declare different properties leaves no
+  // object able to satisfy both. Leaving case 3 untouched also means
+  // non-OpenAI endpoints in this family, which may not implement OpenAI's
+  // strict contract at all, see exactly the schema the caller wrote.
+  //
+  // Case 1 matters for parity: a Zod schema whose properties are all required
+  // already converts to a strict-legal shape, so it goes out byte-identical to
+  // what it did before this change.
+  const original = rf.schema;
+  const closed = withClosedObjects(original) as Record<string, unknown>;
+  const schema = satisfiesStrictRequired(original)
+    ? original
+    : satisfiesStrictRequired(closed)
+      ? closed
+      : original;
   return {
     type: "json_schema",
     json_schema: {
       name: rf.name ?? "response",
-      schema: rf.schema as never,
+      schema: schema as never,
       ...(rf.description ? { description: rf.description } : {}),
-      strict: true,
+      strict: satisfiesStrictRequired(schema),
     },
   };
 };

--- a/test/continuous-test-suite-json-e2e.ts
+++ b/test/continuous-test-suite-json-e2e.ts
@@ -576,4 +576,100 @@ await test("anthropic:claude-sonnet-4-6 — forced truncation yields a partial o
   );
 });
 
+// A Zod schema with ANY optional field converts to `required` missing that
+// property while `additionalProperties: false` is already present — a shape
+// OpenAI's strict mode rejects outright with "'required' is required to be
+// supplied". So `generate({ schema })` failed with a 400, not a degraded
+// answer, for the most ordinary optional field there is.
+//
+// Forcing every property into `required` would satisfy strict mode but would
+// silently make the caller's optional fields mandatory. The request must drop
+// to non-strict instead, which OpenAI accepts and which honours optionality.
+//
+// The absence assertion is the point: without it, an implementation that
+// regressed to forcing `required` would still pass, because the model would
+// return both fields and every other assertion would hold.
+await test("openai:gpt-4o-mini — an optional Zod field stays optional, and is absent when unset", async () => {
+  let res: SchemaResult;
+  try {
+    res = (await nl.generate({
+      input: {
+        text: "Name the capital of France. Do not include a population figure.",
+      },
+      provider: "openai",
+      model: "gpt-4o-mini",
+      maxTokens: 200,
+      schema: z.object({
+        capital: z.string(),
+        population: z.number().optional(),
+      }),
+    })) as SchemaResult;
+  } catch (e) {
+    if (isInfraError(String((e as Error)?.message ?? e))) {
+      throw new Skip("openai unavailable for provider reasons");
+    }
+    throw new Error(
+      "a schema with an optional property was rejected outright",
+      { cause: e },
+    );
+  }
+  const data = res.structuredData as Record<string, unknown> | undefined;
+  assert(
+    !!data && typeof data === "object" && !Array.isArray(data),
+    "structuredData must be a plain object",
+  );
+  assert(
+    typeof data?.capital === "string" && (data.capital as string).length > 0,
+    "the required property must be present and non-empty",
+  );
+  assert(
+    data !== undefined && !("population" in data),
+    "the optional property must be absent, proving it was not forced into required",
+  );
+  console.log(
+    "      · optional Zod field honoured and absent — request not rejected",
+  );
+});
+
+// The same shared path carries the whole OpenAI-compatible family, so pin a
+// second member of it. Azure is the right second cell here: it is the other
+// provider that opts OUT of suppressing response_format with tools, so it
+// actually exercises the `json_schema` + strict decision this change makes,
+// rather than a provider whose format is downgraded or suppressed before the
+// decision matters.
+await test("azure — an optional field survives on a second family member", async () => {
+  const azureModel = process.env.AZURE_OPENAI_MODEL ?? process.env.AZURE_MODEL;
+  if (!azureModel) {
+    throw new Skip("no azure deployment configured");
+  }
+  let res: SchemaResult;
+  try {
+    res = (await nl.generate({
+      input: {
+        text: "Name the capital of France. Do not include a population figure.",
+      },
+      provider: "azure",
+      model: azureModel,
+      maxTokens: 200,
+      schema: z.object({
+        capital: z.string(),
+        population: z.number().optional(),
+      }),
+    })) as SchemaResult;
+  } catch (e) {
+    if (isInfraError(String((e as Error)?.message ?? e))) {
+      throw new Skip("azure unavailable for provider reasons");
+    }
+    throw new Error("optional-field schema failed on a second provider", {
+      cause: e,
+    });
+  }
+  const data = res.structuredData as Record<string, unknown> | undefined;
+  assert(
+    !!data && typeof data === "object",
+    "structuredData must be produced on the shared family path too",
+  );
+  console.log("      · optional field honoured on a second family member");
+});
+
 await runSuite();


### PR DESCRIPTION
`generate({ schema })` is documented to return valid JSON plus a parsed `structuredData` for every provider. On OpenAI it did the opposite for the most ordinary input there is: **a plain JSON Schema failed the request outright with a 400.**

## The bug

`v3ResponseFormatToOpenAI` sent `strict: true` with the caller's schema untouched. OpenAI's strict structured-output mode rejects a schema unless every object node carries `additionalProperties: false` **and** lists every one of its properties in `required` — recursively, including through array `items`. A plain JSON Schema satisfies neither.

## The contract, learned from the vendor

Each rule confirmed by sending the shape and reading the refusal, not assumed:

| schema | result |
|---|---|
| bare object | `400` `'additionalProperties' is required` |
| `+ additionalProperties:false` | `200` OK |
| `required` omits one property | `400` `'required' is required to be supplied` |
| nested object without `AP:false` | `400` `context=('properties','city')` |
| array `items` without `AP:false` | `400` `context=('properties','rows','items')` |

## Why this fix does not just force `required`

Adding `additionalProperties: false` is safe — it forbids keys the caller never asked for, which strict mode forbids anyway.

Filling in `required` is **not** safe: it would silently make the caller's optional fields mandatory. So a schema that still has optional properties after normalisation drops to `strict: false`, which OpenAI accepts and which honours optionality — confirmed live, it returned `{"capital":"Paris"}` with `population` absent. Schemas that are already strict-compatible keep the stronger `strict: true` guarantee.

## How it was found

A measured feature matrix across 16 providers showed `json` failing while `toolsJson` passed **on the same rows**. That contradiction pointed straight at the cause: the repo already has `fixSchemaForOpenAIStrictMode`, but it is wired only into tool-parameter schemas in `ToolsManager` — never into the caller's `schema`.

## Verification

Four cases against live OpenAI on the built package:

```
plain schema (was a hard 400)     OK  {"capital":"Paris","population":2140526}
optional field stays optional     OK  {"capital":"Paris","population":2148000}
already strict-compatible         OK  {"capital":"Paris","population":2140526}
nested object                     OK  {"city":{"name":"Paris"}}
```

The first version of this fix recursed into `properties` as though the map were itself a schema node, so nested objects were never closed and the nested case still failed live. Fixed by treating `properties`/`$defs`/`definitions` as maps of schemas and `items`/`anyOf`/`oneOf`/`allOf`/`not` as nodes.

Two live regression tests added to the OpenAI cell of `continuous-test-suite-json-e2e`. Their assertion messages never quote the payload, so a real break cannot be downgraded to a skip by the harness classifier.

`pnpm run pre-push`: 14 passed.

## Note for reviewers

That suite sets `NEUROLINK_DISABLE_BUILTIN_TOOLS=true` at the top, so it does not exercise the default configuration where built-in tools are active. Worth a separate look — it is why this never showed up there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved structured JSON responses for OpenAI-compatible providers by automatically closing object schemas when supported.
  - Preserved optional fields without incorrectly requiring them.
  - Applied strict validation only when schemas are fully compatible, improving handling of complex schemas and unspecified additional properties.
  - Improved compatibility with Azure structured outputs and reduced request rejections for valid schemas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->